### PR TITLE
fix: initialize theme toggle before theme logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+const themeToggle = document.getElementById('themeToggle');
+
 // ====== Preferencias de tema (claro/oscuro)
 (function initTheme() {
   try {
@@ -8,8 +10,6 @@
     updateThemeToggle(theme);
   } catch(e) {}
 })();
-
-const themeToggle = document.getElementById('themeToggle');
 themeToggle.addEventListener('click', () => {
   const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
   const next = current === 'dark' ? 'light' : 'dark';


### PR DESCRIPTION
## Summary
- ensure `themeToggle` is defined before any call to `updateThemeToggle`
- run theme initialization after `themeToggle` is declared

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a1d9e0bc832ba2b3a2c62e8d9773