### PR TITLE
fix: define panel-rgb for theme header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,6 @@
 :root {
   --bg: #ffffff;
+  --panel-rgb: 248,250,252;
   --panel: #f8fafc; /* slate-50 */
   --text: #0f172a;  /* slate-900 */
   --muted: #334155; /* slate-700 */
@@ -13,6 +14,7 @@
 }
 [data-theme="dark"] {
   --bg: #0b1020;    /* deep slate */
+  --panel-rgb: 15,23,42;
   --panel: #0f172a;
   --text: #e5e7eb;  /* slate-200 */
   --muted: #a1a1aa; /* zinc-400 */


### PR DESCRIPTION
## Summary
- add `--panel-rgb` variable for light theme
- add `--panel-rgb` variable for dark theme

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a5adbe5c832b99f7fd292971baf6