### PR TITLE
Replace theme button with switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,10 +63,10 @@
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
           <input id="q" type="search" placeholder="Buscar en el sitio…" autocomplete="off" />
         </label>
-        <button id="themeToggle" class="btn" aria-pressed="false" aria-label="Cambiar a modo oscuro">
-          <span class="icon" aria-hidden="true">🌙</span>
-          <span class="txt">Oscuro</span>
-        </button>
+        <label class="switch">
+          <input id="themeToggle" type="checkbox" aria-label="Cambiar a modo oscuro" />
+          <span class="slider"></span>
+        </label>
       </div>
     </div>
   </header>

--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const themeToggle = document.getElementById('themeToggle');
     updateThemeToggle(theme);
   } catch(e) {}
 })();
-themeToggle.addEventListener('click', () => {
+themeToggle.addEventListener('change', () => {
   const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
   const next = current === 'dark' ? 'light' : 'dark';
   document.documentElement.setAttribute('data-theme', next);
@@ -20,9 +20,7 @@ themeToggle.addEventListener('click', () => {
 
 function updateThemeToggle(theme) {
   const isDark = theme === 'dark';
-  themeToggle.setAttribute('aria-pressed', String(isDark));
-  themeToggle.querySelector('.icon').textContent = isDark ? '☀️' : '🌙';
-  themeToggle.querySelector('.txt').textContent = isDark ? 'Claro' : 'Oscuro';
+  themeToggle.checked = isDark;
   themeToggle.setAttribute('aria-label', isDark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro');
 }
 

--- a/styles.css
+++ b/styles.css
@@ -73,6 +73,46 @@ header.site-header {
 }
 .search input { border: none; outline: none; background: transparent; color: var(--text); width: 100%; font-size: 15px; }
 
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 24px;
+}
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  transition: background .2s;
+}
+.slider:before {
+  content: "";
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: var(--text);
+  border-radius: 50%;
+  transition: transform .2s, background .2s;
+}
+.switch input:checked + .slider {
+  background: var(--text);
+}
+.switch input:checked + .slider:before {
+  transform: translate(16px, -50%);
+  background: var(--bg);
+}
+
 /* Hero */
 .hero { display: grid; gap: 20px; grid-template-columns: 1.2fr .8fr; padding: 28px 0; }
 .hero-card, .mini { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); overflow: hidden; }


### PR DESCRIPTION
## Summary
- use checkbox switch in header instead of text button
- style the new theme switch slider
- sync toggle state and aria-label with active theme

## Testing
- `node` script toggles from light to dark and stores theme
- `node` script with preset dark theme loads checked state
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0acc5c8d8832b9874e2b883b001b3