### PR TITLE
Use Bootstrap icons for interface graphics

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
   </script>
 
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css">
 </head>
 <body>
   <a href="#contenido" class="visually-hidden">Saltar al contenido</a>
@@ -60,7 +61,7 @@
 
       <div class="actions">
         <label class="search" aria-label="Buscar artículos">
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          <i class="bi bi-search"></i>
           <input id="q" type="search" placeholder="Buscar en el sitio…" autocomplete="off" />
         </label>
         <label class="switch">
@@ -76,7 +77,7 @@
     <section class="hero" aria-labelledby="destacados">
       <article class="hero-card">
         <div class="hero-media" aria-hidden="true">
-          <svg width="96" height="96" viewBox="0 0 24 24" fill="none"><path d="M4 6h16M4 12h16M4 18h10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          <i class="bi bi-list"></i>
         </div>
         <div class="pad">
           <span class="kicker">Último minuto</span>
@@ -117,7 +118,7 @@
     <!-- LISTADO PRINCIPAL -->
     <section class="section" aria-labelledby="ultimas">
       <h2 id="ultimas">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 6h16M4 12h10M4 18h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+        <i class="bi bi-list"></i>
         Últimas publicaciones
       </h2>
       <div id="articles" class="grid" role="list"></div>

--- a/styles.css
+++ b/styles.css
@@ -71,6 +71,7 @@ header.site-header {
 .search {
   display: flex; align-items: center; gap: 10px; padding: 10px 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--panel); min-width: 240px;
 }
+.search .bi { font-size: 18px; }
 .search input { border: none; outline: none; background: transparent; color: var(--text); width: 100%; font-size: 15px; }
 
 .switch {
@@ -117,7 +118,7 @@ header.site-header {
 .hero { display: grid; gap: 20px; grid-template-columns: 1.2fr .8fr; padding: 28px 0; }
 .hero-card, .mini { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); overflow: hidden; }
 .hero-media { aspect-ratio: 16/9; background: linear-gradient(135deg, rgba(2,132,199,.2), rgba(168,85,247,.18)); display: grid; place-items: center; }
-.hero-media svg { width: 72px; height: 72px; opacity: .9; }
+.hero-media .bi { font-size: 72px; opacity: .9; }
 .pad { padding: 16px; }
 .kicker { color: var(--accent); text-transform: uppercase; font-weight: 800; letter-spacing: .6px; font-size: 12px; }
 .title-xl { font-size: clamp(22px, 4.2vw, 34px); line-height: 1.15; margin: 6px 0 10px; font-weight: 900; }
@@ -132,6 +133,7 @@ header.site-header {
 /* Grid */
 .section { padding: 8px 0 40px; }
 .section h2 { font-size: 20px; margin: 0 0 16px; display: flex; align-items: center; gap: 10px; }
+.section h2 .bi { font-size: 20px; }
 .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .card { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); overflow: hidden; display: grid; grid-template-rows: auto 1fr auto; }
 .card .thumb { aspect-ratio: 16/9; background: linear-gradient(135deg, rgba(34,197,94,.18), rgba(59,130,246,.18)); }


### PR DESCRIPTION
## Summary
- add Bootstrap Icons stylesheet
- swap inline SVGs for `<i class="bi">` elements
- style icons for search, hero card, and list heading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b7918a10832b9c01e88ce1893ec1