### PR TITLE
Load articles from Blogger API and update filters

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,65 +24,36 @@ function updateThemeToggle(theme) {
   themeToggle.setAttribute('aria-label', isDark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro');
 }
 
-// ====== Datos de ejemplo (reemplaza con tu CMS/API)
-const ARTICLES = [
-  {
-    id: 1,
-    titulo: 'Argentina prueba identidad digital soberana con estándares abiertos',
-    resumen: 'El piloto se enfoca en servicios públicos y evita el bloqueo por proveedor gracias a credenciales verificables.',
-    categoria: 'Tecnología',
-    etiquetas: ['identidad', 'gobierno digital'],
-    fecha: '2025-08-10',
-    lectura: '4 min'
-  },
-  {
-    id: 2,
-    titulo: 'Investigadoras peruanas logran bioplástico a partir de residuos de papa',
-    resumen: 'Una alternativa compostable con propiedades similares al PE para empaques alimentarios.',
-    categoria: 'Ciencia',
-    etiquetas: ['materiales', 'sostenibilidad'],
-    fecha: '2025-08-08',
-    lectura: '5 min'
-  },
-  {
-    id: 3,
-    titulo: 'Brasil impulsa chips RISC-V en universidades públicas',
-    resumen: 'Nuevos laboratorios de diseño y un fondo semilla para prototipos locales abren camino a la fabricación regional.',
-    categoria: 'Tecnología',
-    etiquetas: ['hardware', 'risc-v'],
-    fecha: '2025-08-05',
-    lectura: '6 min'
-  },
-  {
-    id: 4,
-    titulo: 'Vacuna termoestable contra dengue muestra eficacia en fase II',
-    resumen: 'El candidato mantiene potencia a temperatura ambiente, clave para climas tropicales.',
-    categoria: 'Ciencia',
-    etiquetas: ['salud', 'vacunas'],
-    fecha: '2025-08-01',
-    lectura: '7 min'
-  },
-  {
-    id: 5,
-    titulo: 'Startups edtech latinoamericanas adoptan IA para tutorías personalizadas',
-    resumen: 'Plataformas en español y portugués mejoran retención y acceso en zonas rurales.',
-    categoria: 'Startups',
-    etiquetas: ['educación', 'IA'],
-    fecha: '2025-07-30',
-    lectura: '3 min'
-  },
-  {
-    id: 6,
-    titulo: 'Opinión: regular la IA sin frenar la innovación en la región',
-    resumen: 'Marcos de riesgo, sandboxes regulatorios y cooperación transfronteriza.',
-    categoria: 'Opinión',
-    etiquetas: ['política pública', 'IA'],
-    fecha: '2025-07-28',
-    lectura: '4 min'
-  }
-];
+// ====== Datos de artículos (se cargan dinámicamente)
+let articles = [];
 
 const articlesEl = document.getElementById('articles');
+
+async function loadArticles() {
+  const url = 'https://www.googleapis.com/blogger/v3/blogs/4840049977445065362/posts?key=AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA';
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    const mapped = (data.items || []).map(item => {
+      const text = stripHtml(item.content || '');
+      return {
+        id: item.id,
+        titulo: item.title || '',
+        resumen: text.slice(0, 160) + (text.length > 160 ? '…' : ''),
+        categoria: (item.labels && item.labels[0]) || 'General',
+        etiquetas: item.labels ? item.labels.slice(1) : [],
+        fecha: item.published ? item.published.split('T')[0] : '',
+        lectura: estimateReadingTime(text)
+      };
+    });
+    articles = mapped;
+    renderArticles(articles);
+  } catch (err) {
+    console.error('Error al cargar artículos', err);
+    articlesEl.innerHTML = '<p>No se pudieron cargar los artículos.</p>';
+  }
+}
 
 function renderArticles(list) {
   articlesEl.innerHTML = '';
@@ -111,7 +82,18 @@ function formatDate(iso) {
   } catch(e) { return iso; }
 }
 
-renderArticles(ARTICLES);
+function stripHtml(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.textContent || div.innerText || '';
+}
+
+function estimateReadingTime(text) {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words / 200)) + ' min';
+}
+
+loadArticles();
 
 // ====== Filtro por categoría
 const links = document.querySelectorAll('.nav-links [data-filter]');
@@ -120,8 +102,8 @@ links.forEach(link => link.addEventListener('click', (e) => {
   const f = link.getAttribute('data-filter');
   links.forEach(l => l.removeAttribute('aria-current'));
   link.setAttribute('aria-current', 'page');
-  if (f === 'todas') { renderArticles(ARTICLES); return; }
-  renderArticles(ARTICLES.filter(a => a.categoria === f));
+  if (f === 'todas') { renderArticles(articles); return; }
+  renderArticles(articles.filter(a => a.categoria === f));
 }));
 
 // ====== Búsqueda simple
@@ -129,7 +111,7 @@ const q = document.getElementById('q');
 q.addEventListener('input', () => {
   const term = q.value.trim().toLowerCase();
   const base = document.querySelector('.nav-links [aria-current="page"]').getAttribute('data-filter');
-  const pool = base === 'todas' ? ARTICLES : ARTICLES.filter(a => a.categoria === base);
+  const pool = base === 'todas' ? articles : articles.filter(a => a.categoria === base);
   const results = !term ? pool : pool.filter(a => (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term));
   renderArticles(results);
 });


### PR DESCRIPTION
## Summary
- Replace static article list with dynamic `articles` array loaded from Blogger API.
- Map Blogger posts to internal format including reading-time estimation and HTML stripping.
- Update filters and search to operate on fetched articles and handle fetch errors.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d2db9b10832bada399f91584bcec