### PR TITLE
Add individual post page and link article cards

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,9 +58,12 @@ async function loadArticles() {
 function renderArticles(list) {
   articlesEl.innerHTML = '';
   list.forEach(a => {
+    const link = document.createElement('a');
+    link.href = `post.html?id=${a.id}`;
+    link.setAttribute('role', 'listitem');
+
     const el = document.createElement('article');
     el.className = 'card';
-    el.setAttribute('role', 'listitem');
     el.innerHTML = `
       <div class="thumb" aria-hidden="true"></div>
       <div class="pad">
@@ -71,7 +74,8 @@ function renderArticles(list) {
       </div>
       <div class="pad meta"><span>${formatDate(a.fecha)}</span><span>•</span><span>${a.lectura}</span></div>
     `;
-    articlesEl.appendChild(el);
+    link.appendChild(el);
+    articlesEl.appendChild(link);
   });
 }
 

--- a/post.html
+++ b/post.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es-419" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>TecnoCiencia LATAM — Artículo</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="container" tabindex="-1">
+    <article id="post">
+      <h1 id="post-title"></h1>
+      <div id="post-meta" class="meta"></div>
+      <div id="post-content"></div>
+    </article>
+  </main>
+  <script src="post.js" defer></script>
+</body>
+</html>

--- a/post.js
+++ b/post.js
@@ -1,0 +1,49 @@
+const params = new URLSearchParams(window.location.search);
+const id = params.get('id');
+const blogId = '4840049977445065362';
+const apiKey = 'AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA';
+
+const titleEl = document.getElementById('post-title');
+const metaEl = document.getElementById('post-meta');
+const contentEl = document.getElementById('post-content');
+
+function formatDate(iso) {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString('es-419', { year: 'numeric', month: 'long', day: 'numeric' });
+  } catch (e) { return iso; }
+}
+
+function stripHtml(html) {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.textContent || div.innerText || '';
+}
+
+function estimateReadingTime(text) {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words / 200)) + ' min de lectura';
+}
+
+async function loadPost() {
+  if (!id) {
+    titleEl.textContent = 'Artículo no encontrado';
+    return;
+  }
+  const url = `https://www.googleapis.com/blogger/v3/blogs/${blogId}/posts/${id}?key=${apiKey}`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    titleEl.textContent = data.title || '';
+    const text = stripHtml(data.content || '');
+    const meta = [data.author && data.author.displayName, formatDate(data.published), estimateReadingTime(text)].filter(Boolean).join(' • ');
+    metaEl.textContent = meta;
+    contentEl.innerHTML = data.content || '';
+  } catch (err) {
+    titleEl.textContent = 'Error al cargar el artículo';
+    console.error(err);
+  }
+}
+
+loadPost();


### PR DESCRIPTION
## Summary
- create `post.html` and `post.js` to display full article data fetched from the Blogger API
- update article card rendering so each links to the new post page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e389b4b0832bb333e8139d11bea6