### PR TITLE
Display latest posts in hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,44 +81,9 @@
   <main id="contenido" class="container" tabindex="-1">
     <!-- HERO -->
     <section class="hero" aria-labelledby="destacados">
-      <article class="hero-card">
-        <div class="hero-media" aria-hidden="true">
-          <i class="bi bi-list"></i>
-        </div>
-        <div class="pad">
-          <span class="kicker">Último minuto</span>
-          <h1 class="title-xl" id="destacados">La IA latinoamericana acelera en salud pública con modelos bilingües</h1>
-          <p>Investigadores de México y Colombia liberan modelos de IA entrenados en español e inglés para detección temprana de brotes. Analizamos el impacto, los sesgos y los próximos retos.</p>
-          <div class="meta"><span>Por Redacción</span><span>•</span><span>Hoy</span><span>•</span><span>5 min de lectura</span></div>
-        </div>
-      </article>
+      <article id="hero" class="hero-card"></article>
 
-      <div class="mini-list" aria-label="Más notas destacadas">
-        <article class="mini">
-          <div class="thumb" aria-hidden="true"></div>
-          <div class="pad">
-            <span class="kicker">Energía</span>
-            <h3>Chile rompe récord en almacenamiento con baterías de litio-ferrofosfato</h3>
-            <div class="meta"><span>LatAm</span><span>•</span><span>4 min de lectura</span></div>
-          </div>
-        </article>
-        <article class="mini">
-          <div class="thumb" aria-hidden="true"></div>
-          <div class="pad">
-            <span class="kicker">Startups</span>
-            <h3>Fintech mexicana lanza cuenta sin comisiones para estudiantes</h3>
-            <div class="meta"><span>México</span><span>•</span><span>3 min de lectura</span></div>
-          </div>
-        </article>
-        <article class="mini">
-          <div class="thumb" aria-hidden="true"></div>
-          <div class="pad">
-            <span class="kicker">Ciencia</span>
-            <h3>Telescopios de Atacama detectan posible exoplaneta templado</h3>
-            <div class="meta"><span>Observatorio</span><span>•</span><span>6 min de lectura</span></div>
-          </div>
-        </article>
-      </div>
+      <div id="mini-list" class="mini-list" aria-label="Más notas destacadas"></div>
     </section>
 
     <!-- LISTADO PRINCIPAL -->

--- a/main.js
+++ b/main.js
@@ -47,7 +47,8 @@ async function loadArticles() {
         lectura: estimateReadingTime(text)
       };
     });
-    articles = mapped;
+    renderHero(mapped);
+    articles = mapped.slice(4);
     renderArticles(articles);
   } catch (err) {
     console.error('Error al cargar artículos', err);
@@ -76,6 +77,41 @@ function renderArticles(list) {
     `;
     link.appendChild(el);
     articlesEl.appendChild(link);
+  });
+}
+
+function renderHero(list) {
+  const heroEl = document.getElementById('hero');
+  const miniListEl = document.getElementById('mini-list');
+  if (!heroEl || !miniListEl || !list.length) return;
+
+  const [first, ...rest] = list;
+  heroEl.innerHTML = `
+    <a href="post.html?id=${first.id}">
+      <div class="hero-media" aria-hidden="true"><i class="bi bi-list"></i></div>
+      <div class="pad">
+        <span class="kicker">${first.categoria}</span>
+        <h1 class="title-xl" id="destacados">${first.titulo}</h1>
+        <p>${first.resumen}</p>
+        <div class="meta"><span>${formatDate(first.fecha)}</span><span>•</span><span>${first.lectura}</span></div>
+      </div>
+    </a>
+  `;
+
+  miniListEl.innerHTML = '';
+  rest.slice(0,3).forEach(a => {
+    const link = document.createElement('a');
+    link.href = `post.html?id=${a.id}`;
+    link.className = 'mini';
+    link.innerHTML = `
+      <div class="thumb" aria-hidden="true"></div>
+      <div class="pad">
+        <span class="kicker">${a.categoria}</span>
+        <h3>${a.titulo}</h3>
+        <div class="meta"><span>${formatDate(a.fecha)}</span><span>•</span><span>${a.lectura}</span></div>
+      </div>
+    `;
+    miniListEl.appendChild(link);
   });
 }
 


### PR DESCRIPTION
## Summary
- Populate hero card and mini list using latest Blogger posts
- Exclude featured posts from main list rendering

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef568688832b8f78121861250253