### PR TITLE
feat: add cookie consent banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,11 @@
     </div>
   </footer>
 
+  <div id="cookie-banner" class="cookie-banner" role="dialog" aria-modal="true" tabindex="0" aria-label="Aviso de cookies">
+    <p>Usamos cookies para mejorar la experiencia del usuario.</p>
+    <button id="cookie-accept" class="cookie-btn">Aceptar</button>
+  </div>
+
   <script src="main.js" defer></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -166,3 +166,23 @@ document.getElementById('newsletterForm').addEventListener('submit', (e) => {
 
 // Año en footer
 document.getElementById('y').textContent = new Date().getFullYear();
+
+// ====== Cookie consent
+(function () {
+  const banner = document.getElementById('cookie-banner');
+  const btn = document.getElementById('cookie-accept');
+  if (!banner || !btn) return;
+  let previous = null;
+  if (!localStorage.getItem('cookieConsent')) {
+    banner.classList.add('show');
+    previous = document.activeElement;
+    btn.focus();
+  }
+  btn.addEventListener('click', () => {
+    banner.classList.remove('show');
+    localStorage.setItem('cookieConsent', 'true');
+    if (previous && typeof previous.focus === 'function') {
+      previous.focus();
+    }
+  });
+})();

--- a/post.html
+++ b/post.html
@@ -76,6 +76,10 @@
       <div class="meta">Edición: Latinoamérica • Español (es-419)</div>
     </div>
   </footer>
+  <div id="cookie-banner" class="cookie-banner" role="dialog" aria-modal="true" tabindex="0" aria-label="Aviso de cookies">
+    <p>Usamos cookies para mejorar la experiencia del usuario.</p>
+    <button id="cookie-accept" class="cookie-btn">Aceptar</button>
+  </div>
   <script src="post.js" defer></script>
 </body>
 </html>

--- a/post.js
+++ b/post.js
@@ -84,3 +84,23 @@ document.getElementById('newsletterForm').addEventListener('submit', (e) => {
 
 // Año en footer
 document.getElementById('y').textContent = new Date().getFullYear();
+
+// ====== Cookie consent
+(function () {
+  const banner = document.getElementById('cookie-banner');
+  const btn = document.getElementById('cookie-accept');
+  if (!banner || !btn) return;
+  let previous = null;
+  if (!localStorage.getItem('cookieConsent')) {
+    banner.classList.add('show');
+    previous = document.activeElement;
+    btn.focus();
+  }
+  btn.addEventListener('click', () => {
+    banner.classList.remove('show');
+    localStorage.setItem('cookieConsent', 'true');
+    if (previous && typeof previous.focus === 'function') {
+      previous.focus();
+    }
+  });
+})();

--- a/styles.css
+++ b/styles.css
@@ -161,6 +161,42 @@ header.site-header {
 .newsletter form { display: grid; grid-template-columns: 1fr auto; gap: 10px; }
 .input { padding: 12px 14px; border-radius: 12px; border: 1px solid var(--border); background: var(--bg); color: var(--text); }
 
+/* Cookie banner */
+.cookie-banner {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 420px;
+  padding: 16px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  display: none;
+  z-index: 100;
+}
+.cookie-banner.show {
+  display: grid;
+  gap: 12px;
+}
+.cookie-banner p {
+  margin: 0;
+}
+.cookie-btn {
+  justify-self: end;
+  padding: 8px 16px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.cookie-btn:focus {
+  outline: 2px solid var(--accent-2);
+}
+
 /* Footer */
 footer { border-top: 1px solid var(--border); padding: 22px 0 60px; color: var(--muted); }
 .foot { display: grid; gap: 16px; grid-template-columns: 1fr auto; align-items: center; }


### PR DESCRIPTION
## Summary
- add cookie banner markup on index and post pages
- style banner and button
- store user consent in localStorage and restore focus when closed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a121b49368832b9e803058993657a1