### PR TITLE
feat: add search to post page

### DIFF
--- a/post.html
+++ b/post.html
@@ -27,7 +27,7 @@
       </a>
 
       <nav class="nav-links">
-        <a class="chip" href="#" data-filter="todas">Inicio</a>
+        <a class="chip" href="#" data-filter="todas" aria-current="page">Inicio</a>
         <a class="chip" href="#" data-filter="Tecnología">Tecnología</a>
         <a class="chip" href="#" data-filter="Ciencia">Ciencia</a>
         <a class="chip" href="#" data-filter="Startups">Startups</a>
@@ -57,6 +57,11 @@
       <div id="post-meta" class="meta"></div>
       <div id="post-content"></div>
     </article>
+
+    <section id="searchSection" class="section" aria-labelledby="resultados" hidden>
+      <h2 id="resultados">Resultados de búsqueda</h2>
+      <div id="articles" class="grid" role="list"></div>
+    </section>
 
     <!-- NEWSLETTER -->
     <section class="section" aria-labelledby="boletin">

--- a/post.js
+++ b/post.js
@@ -51,6 +51,11 @@ function estimateReadingTime(text) {
   return Math.max(1, Math.ceil(words / 200)) + ' min de lectura';
 }
 
+function estimateReadingTimeShort(text) {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.ceil(words / 200)) + ' min';
+}
+
 async function loadPost() {
   if (!id) {
     titleEl.textContent = 'Artículo no encontrado';
@@ -73,6 +78,93 @@ async function loadPost() {
 }
 
 loadPost();
+
+// ====== Búsqueda y filtrado de artículos
+let articles = [];
+const searchSection = document.getElementById('searchSection');
+const articlesEl = document.getElementById('articles');
+
+async function loadArticles() {
+  const url = 'https://www.googleapis.com/blogger/v3/blogs/4840049977445065362/posts?key=AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA';
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(res.statusText);
+    const data = await res.json();
+    articles = (data.items || []).map(item => {
+      const text = stripHtml(item.content || '');
+      return {
+        id: item.id,
+        titulo: item.title || '',
+        resumen: text.slice(0, 160) + (text.length > 160 ? '…' : ''),
+        categoria: (item.labels && item.labels[0]) || 'General',
+        etiquetas: item.labels ? item.labels.slice(1) : [],
+        fecha: item.published ? item.published.split('T')[0] : '',
+        lectura: estimateReadingTimeShort(text)
+      };
+    });
+  } catch (err) {
+    console.error('Error al cargar artículos', err);
+  }
+}
+
+function renderArticles(list) {
+  if (!searchSection || !articlesEl) return;
+  searchSection.hidden = false;
+  articlesEl.innerHTML = '';
+  list.forEach(a => {
+    const link = document.createElement('a');
+    link.href = `post.html?id=${a.id}`;
+    link.setAttribute('role', 'listitem');
+
+    const el = document.createElement('article');
+    el.className = 'card';
+    el.innerHTML = `
+      <div class="thumb" aria-hidden="true"></div>
+      <div class="pad">
+        <span class="kicker">${a.categoria}</span>
+        <h3>${a.titulo}</h3>
+        <p>${a.resumen}</p>
+        <div class="tags">${a.etiquetas.map(t => `<span class='tag'>#${t}</span>`).join('')}</div>
+      </div>
+      <div class="pad meta"><span>${formatDate(a.fecha)}</span><span>•</span><span>${a.lectura}</span></div>
+    `;
+    link.appendChild(el);
+    articlesEl.appendChild(link);
+  });
+}
+
+loadArticles();
+
+// ====== Filtro por categoría
+const links = document.querySelectorAll('.nav-links [data-filter]');
+links.forEach(link => link.addEventListener('click', (e) => {
+  e.preventDefault();
+  const f = link.getAttribute('data-filter');
+  links.forEach(l => l.removeAttribute('aria-current'));
+  link.setAttribute('aria-current', 'page');
+  const results = f === 'todas' ? articles : articles.filter(a => a.categoria === f);
+  if (!results.length) {
+    searchSection.hidden = false;
+    articlesEl.innerHTML = '<p>No se encontraron coincidencias.</p>';
+  } else {
+    renderArticles(results);
+  }
+}));
+
+// ====== Búsqueda simple
+const q = document.getElementById('q');
+q.addEventListener('input', () => {
+  const term = q.value.trim().toLowerCase();
+  const base = document.querySelector('.nav-links [aria-current="page"]').getAttribute('data-filter');
+  const pool = base === 'todas' ? articles : articles.filter(a => a.categoria === base);
+  const results = !term ? pool : pool.filter(a => (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term));
+  if (!results.length) {
+    searchSection.hidden = false;
+    articlesEl.innerHTML = '<p>No se encontraron coincidencias.</p>';
+  } else {
+    renderArticles(results);
+  }
+});
 
 // ====== Newsletter (demo)
 document.getElementById('newsletterForm').addEventListener('submit', (e) => {


### PR DESCRIPTION
## Summary
- enable article search on post page with category filters and result rendering
- add hidden search results section and set default nav state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a132478a5c832ba16f0232e390ded4