### PR TITLE
Handle default filter without Inicio chip

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,6 @@
       </a>
 
       <nav class="nav-links">
-        <a class="chip" href="#" data-filter="todas" aria-current="page">Inicio</a>
         <a class="chip" href="#" data-filter="Tecnología">Tecnología</a>
         <a class="chip" href="#" data-filter="Ciencia">Ciencia</a>
         <a class="chip" href="#" data-filter="Startups">Startups</a>

--- a/main.js
+++ b/main.js
@@ -159,7 +159,8 @@ links.forEach(link => link.addEventListener('click', (e) => {
 const q = document.getElementById('q');
 q.addEventListener('input', () => {
   const term = q.value.trim().toLowerCase();
-  const base = document.querySelector('.nav-links [aria-current="page"]').getAttribute('data-filter');
+  const current = document.querySelector('.nav-links [aria-current="page"]');
+  const base = current ? current.getAttribute('data-filter') : 'todas';
   const pool = base === 'todas' ? articles : articles.filter(a => a.categoria === base);
   const results = !term ? pool : pool.filter(a => (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term));
   renderArticles(results);

--- a/post.html
+++ b/post.html
@@ -29,7 +29,6 @@
       </a>
 
       <nav class="nav-links">
-        <a class="chip" href="#" data-filter="todas" aria-current="page">Inicio</a>
         <a class="chip" href="#" data-filter="Tecnología">Tecnología</a>
         <a class="chip" href="#" data-filter="Ciencia">Ciencia</a>
         <a class="chip" href="#" data-filter="Startups">Startups</a>

--- a/post.js
+++ b/post.js
@@ -111,6 +111,7 @@ async function loadArticles() {
         lectura: estimateReadingTimeShort(text)
       };
     });
+    renderArticles(articles);
   } catch (err) {
     console.error('Error al cargar artículos', err);
   }
@@ -164,7 +165,8 @@ links.forEach(link => link.addEventListener('click', (e) => {
 const q = document.getElementById('q');
 q.addEventListener('input', () => {
   const term = q.value.trim().toLowerCase();
-  const base = document.querySelector('.nav-links [aria-current="page"]').getAttribute('data-filter');
+  const current = document.querySelector('.nav-links [aria-current="page"]');
+  const base = current ? current.getAttribute('data-filter') : 'todas';
   const pool = base === 'todas' ? articles : articles.filter(a => a.categoria === base);
   const results = !term ? pool : pool.filter(a => (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term));
   if (!results.length) {


### PR DESCRIPTION
## Summary
- remove "Inicio" chip from navigation links
- guard search logic when no category is selected
- render all articles by default on post page

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a142fd1f8c832b8aca0adc98f68365