### PR TITLE
Add panel background styling to footer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -386,7 +386,13 @@ header.site-header {
 }
 
 /* Footer */
-footer { border-top: 1px solid var(--border); padding: 22px 0 60px; color: var(--muted); }
+footer {
+  background: rgba(var(--panel-rgb), 0.7);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid var(--border);
+  padding: 22px 0 60px;
+  color: var(--muted);
+}
 .foot { display: grid; gap: 16px; grid-template-columns: 1fr auto; align-items: center; }
 
 .social-cards {


### PR DESCRIPTION
## Summary
- give site footer a translucent panel-style background with blur effect

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a155e49098832bbc0a59ea7eca62b8