### PR TITLE
feat: add social card styles from codepen

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -253,6 +253,65 @@ header.site-header {
 .tags { display: flex; gap: 8px; flex-wrap: wrap; }
 .tag { font-size: 12px; padding: 4px 10px; border-radius: 999px; background: rgba(2,132,199,.14); color: var(--muted); border: 1px dashed var(--border); }
 
+/* Social cards */
+.social-cards {
+  display: grid;
+  grid-template-columns: repeat(2, 90px);
+  grid-auto-rows: 90px;
+  gap: 8px;
+  justify-content: center;
+}
+
+.social-cards button {
+  width: 90px;
+  height: 90px;
+  outline: none;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  font-size: 32px;
+  transition: background .3s, color .3s, scale .2s;
+}
+
+.social-cards button:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.card1 { border-radius: 90px 5px 5px 5px; }
+.card2 { border-radius: 5px 90px 5px 5px; }
+.card3 { border-radius: 5px 5px 5px 90px; }
+.card4 { border-radius: 5px 5px 90px 5px; }
+
+.card1 i { color: #cc39a4; }
+.card1:hover,
+.card1:focus { background: #cc39a4; scale: 1.1; }
+.card1:hover i,
+.card1:focus i { color: var(--light); }
+
+.card2 i { color: #1da1f2; }
+.card2:hover,
+.card2:focus { background: #1da1f2; scale: 1.1; }
+.card2:hover i,
+.card2:focus i { color: var(--light); }
+
+.card3 i { color: #333; }
+.card3:hover,
+.card3:focus { background: #333; scale: 1.1; }
+.card3:hover i,
+.card3:focus i { color: var(--light); }
+
+.card4 i { color: #5865f2; }
+.card4:hover,
+.card4:focus { background: #5865f2; scale: 1.1; }
+.card4:hover i,
+.card4:focus i { color: var(--light); }
+
 /* Shared card style for half-width layouts */
 .half-card {
   margin: 20px 0;
@@ -404,56 +463,6 @@ footer {
   color: var(--muted);
 }
 .foot { display: grid; gap: 16px; grid-template-columns: 1fr auto; align-items: center; }
-
-.social-cards {
-  display: flex;
-  gap: 12px;
-  justify-content: center;
-}
-
-.social-cards button {
-  width: 60px;
-  height: 60px;
-  border: none;
-  border-radius: 16px;
-  background: var(--panel);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: var(--shadow);
-  cursor: pointer;
-  font-size: 32px;
-  transition: background .3s, color .3s;
-}
-
-.social-cards button:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.card1 i { color: #cc39a4; }
-.card1:hover,
-.card1:focus { background: #cc39a4; }
-.card1:hover i,
-.card1:focus i { color: var(--light); }
-
-.card2 i { color: #1da1f2; }
-.card2:hover,
-.card2:focus { background: #1da1f2; }
-.card2:hover i,
-.card2:focus i { color: var(--light); }
-
-.card3 i { color: #333; }
-.card3:hover,
-.card3:focus { background: #333; }
-.card3:hover i,
-.card3:focus i { color: var(--light); }
-
-.card4 i { color: #5865f2; }
-.card4:hover,
-.card4:focus { background: #5865f2; }
-.card4:hover i,
-.card4:focus i { color: var(--light); }
 
 /* Responsive */
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- port social card styles from CodePen and place near main card rules
- use theme variables for borders, panels, and shadows
- remove old social card definitions to prevent conflicts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a164199394832ba31d14c384c0e36d