### PR TITLE
Display article images

### DIFF
--- a/main.js
+++ b/main.js
@@ -37,6 +37,7 @@ if (skip) {
 let articles = [];
 
 const articlesEl = document.getElementById('articles');
+const fallbackImage = 'assets/ANXINA-LOGO-NO-BC.webp';
 
 async function loadArticles() {
   const url = 'https://www.googleapis.com/blogger/v3/blogs/4840049977445065362/posts?key=AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA';
@@ -46,6 +47,9 @@ async function loadArticles() {
     const data = await res.json();
     const mapped = (data.items || []).map(item => {
       const text = stripHtml(item.content || '');
+      const div = document.createElement('div');
+      div.innerHTML = item.content || '';
+      const img = div.querySelector('img');
       return {
         id: item.id,
         titulo: item.title || '',
@@ -53,7 +57,8 @@ async function loadArticles() {
         categoria: (item.labels && item.labels[0]) || 'General',
         etiquetas: item.labels ? item.labels.slice(1) : [],
         fecha: item.published ? item.published.split('T')[0] : '',
-        lectura: estimateReadingTime(text)
+        lectura: estimateReadingTime(text),
+        imagen: img ? img.src : fallbackImage
       };
     });
     renderHero(mapped);
@@ -75,7 +80,7 @@ function renderArticles(list) {
     const el = document.createElement('article');
     el.className = 'card';
     el.innerHTML = `
-      <figure class="thumb" aria-hidden="true"></figure>
+      <figure class="thumb" aria-hidden="true"><img src="${a.imagen || fallbackImage}" alt="" loading="lazy"></figure>
       <div class="pad">
         <span class="kicker">${a.categoria}</span>
         <h3>${a.titulo}</h3>

--- a/styles.css
+++ b/styles.css
@@ -249,6 +249,7 @@ header.site-header {
 .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .card { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); overflow: hidden; display: grid; grid-template-rows: auto 1fr auto; }
 .card .thumb { aspect-ratio: 16/9; background: linear-gradient(135deg, rgba(34,197,94,.18), rgba(59,130,246,.18)); }
+.card .thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .card h3 { font-size: 18px; margin: 10px 0; }
 .tags { display: flex; gap: 8px; flex-wrap: wrap; }
 .tag { font-size: 12px; padding: 4px 10px; border-radius: 999px; background: rgba(2,132,199,.14); color: var(--muted); border: 1px dashed var(--border); }


### PR DESCRIPTION
## Summary
- extract the first `<img>` from Blogger content and save its `src` as `imagen`, falling back to the site logo
- render article cards with an `<img>` thumbnail and ensure the image fills the card area

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1662d5344832b8bd6e88a2d08887c