### PR TITLE
fix: set PWA start_url to deployment base

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "TecnoCiencia LATAM",
   "short_name": "TecnoCiencia",
-  "start_url": "/",
+  "start_url": "/Anxina/",
   "display": "standalone",
   "background_color": "#E9EFEC",
   "theme_color": "#16423C",


### PR DESCRIPTION
## Summary
- point PWA manifest `start_url` to `/Anxina/` for GitHub Pages deployment

## Testing
- `node --check main.js`
- `node --check post.js`
- `curl -I http://localhost:8080/Anxina/`
- `curl -I http://localhost:8080/Anxina/icons/android-chrome-192x192.png`
- `curl -I http://localhost:8080/Anxina/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6586328832b81ba2b3af203e223