### PR TITLE
Normalize Blogger API URLs and search filter formatting

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ const articlesEl = document.getElementById('articles');
 const fallbackImage = 'assets/ANXINA-LOGO-NO-BC.webp';
 
 async function loadArticles() {
-  const url = 'https://www.googleapis.com/blogger/v3/blogs/4840049977445065362/posts?key=AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA';
+  const url = `https://www.googleapis.com/blogger/v3/blogs/4840049977445065362/posts?key=AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA`;
   try {
     const res = await fetch(url);
     if (!res.ok) throw new Error(res.statusText);
@@ -166,7 +166,11 @@ q.addEventListener('input', () => {
   const current = document.querySelector('.nav-links [aria-current="page"]');
   const base = current ? current.getAttribute('data-filter') : 'todas';
   const pool = base === 'todas' ? articles : articles.filter(a => a.categoria === base);
-  const results = !term ? pool : pool.filter(a => (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term));
+  const results = !term
+    ? pool
+    : pool.filter(a =>
+        (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term)
+      );
   renderArticles(results);
 });
 

--- a/post.js
+++ b/post.js
@@ -94,7 +94,7 @@ const searchSection = document.getElementById('searchSection');
 const articlesEl = document.getElementById('articles');
 
 async function loadArticles() {
-  const url = 'https://www.googleapis.com/blogger/v3/blogs/4840049977445065362/posts?key=AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA';
+  const url = `https://www.googleapis.com/blogger/v3/blogs/4840049977445065362/posts?key=AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA`;
   try {
     const res = await fetch(url);
     if (!res.ok) throw new Error(res.statusText);
@@ -168,7 +168,11 @@ q.addEventListener('input', () => {
   const current = document.querySelector('.nav-links [aria-current="page"]');
   const base = current ? current.getAttribute('data-filter') : 'todas';
   const pool = base === 'todas' ? articles : articles.filter(a => a.categoria === base);
-  const results = !term ? pool : pool.filter(a => (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term));
+  const results = !term
+    ? pool
+    : pool.filter(a =>
+        (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term)
+      );
   if (!results.length) {
     searchSection.hidden = false;
     articlesEl.innerHTML = '<p>No se encontraron coincidencias.</p>';


### PR DESCRIPTION
## Summary
- use template literals for Blogger API URLs in main.js and post.js
- streamline search filter logic so `.toLowerCase().includes(term)` stays on one line

## Testing
- `node --check main.js`
- `node --check post.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1caf5be60832b8de4a4e7dcb97f49