### PR TITLE
Link social buttons to platforms

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,20 +119,44 @@
     </div>
       <div class="social-cards half-card">
         <div class="up">
-          <button class="card1" aria-label="Instagram">
+          <a
+            class="card1"
+            aria-label="Instagram"
+            href="https://www.instagram.com/anxina/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <i class="bi bi-instagram"></i>
-          </button>
-          <button class="card2" aria-label="Twitter">
+          </a>
+          <a
+            class="card2"
+            aria-label="Twitter"
+            href="https://twitter.com/anxina"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <i class="bi bi-twitter"></i>
-          </button>
+          </a>
         </div>
         <div class="down">
-          <button class="card3" aria-label="GitHub">
+          <a
+            class="card3"
+            aria-label="GitHub"
+            href="https://github.com/tepokato/Anxina"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <i class="bi bi-github"></i>
-          </button>
-          <button class="card4" aria-label="Discord">
+          </a>
+          <a
+            class="card4"
+            aria-label="Discord"
+            href="https://discord.gg/anxina"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <i class="bi bi-discord"></i>
-          </button>
+          </a>
         </div>
       </div>
   </footer>

--- a/post.html
+++ b/post.html
@@ -86,10 +86,34 @@
       <div class="meta">Edición: Latinoamérica • Español (es-419)</div>
     </div>
       <div class="social-cards half-card">
-      <button class="card1" aria-label="Instagram"><i class="bi bi-instagram"></i></button>
-      <button class="card2" aria-label="Twitter"><i class="bi bi-twitter"></i></button>
-      <button class="card3" aria-label="GitHub"><i class="bi bi-github"></i></button>
-      <button class="card4" aria-label="Discord"><i class="bi bi-discord"></i></button>
+      <a
+        class="card1"
+        aria-label="Instagram"
+        href="https://www.instagram.com/anxina/"
+        target="_blank"
+        rel="noopener noreferrer"
+      ><i class="bi bi-instagram"></i></a>
+      <a
+        class="card2"
+        aria-label="Twitter"
+        href="https://twitter.com/anxina"
+        target="_blank"
+        rel="noopener noreferrer"
+      ><i class="bi bi-twitter"></i></a>
+      <a
+        class="card3"
+        aria-label="GitHub"
+        href="https://github.com/tepokato/Anxina"
+        target="_blank"
+        rel="noopener noreferrer"
+      ><i class="bi bi-github"></i></a>
+      <a
+        class="card4"
+        aria-label="Discord"
+        href="https://discord.gg/anxina"
+        target="_blank"
+        rel="noopener noreferrer"
+      ><i class="bi bi-discord"></i></a>
     </div>
   </footer>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-modal="true" tabindex="0" aria-label="Aviso de cookies">

--- a/styles.css
+++ b/styles.css
@@ -281,6 +281,7 @@ header.site-header {
   justify-content: center;
   align-items: center;
   font-size: 1.875em;
+  text-decoration: none;
 }
 
 .card1 { border-radius: 5.625em 0.3125em 0.3125em 0.3125em; color: #cc39a4; }


### PR DESCRIPTION
## Summary
- Replace social media buttons with anchor links to Instagram, Twitter, GitHub, and Discord
- Ensure social links open in new tabs and remove default link styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d7f13b7c832babbc51f9137ca9c7