### PR TITLE
Add real thumbnails with alt text for articles

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,7 +77,7 @@ function renderArticles(list) {
     const el = document.createElement('article');
     el.className = 'card';
     el.innerHTML = `
-      <figure class="thumb" aria-hidden="true"><img src="${a.imagen || fallbackImage}" alt="" loading="lazy"></figure>
+      <figure class="thumb" aria-hidden="true"><img src="${a.imagen || fallbackImage}" alt="${a.titulo}" loading="lazy"></figure>
       <div class="pad">
         <span class="kicker">${a.categoria}</span>
         <h3>${a.titulo}</h3>
@@ -98,7 +98,7 @@ function renderHero(list) {
   const [first, ...rest] = list;
   heroEl.innerHTML = `
     <a href="post.html?id=${first.id}">
-      <div class="thumb" aria-hidden="true"></div>
+      <div class="thumb" aria-hidden="true"><img src="${first.imagen || fallbackImage}" alt="${first.titulo}"></div>
       <div class="pad">
         <span class="kicker">${first.categoria}</span>
         <h1 class="title-xl" id="destacados">${first.titulo}</h1>
@@ -114,7 +114,7 @@ function renderHero(list) {
     link.href = `post.html?id=${a.id}`;
     link.className = 'mini';
     link.innerHTML = `
-      <div class="thumb" aria-hidden="true"></div>
+      <div class="thumb" aria-hidden="true"><img src="${a.imagen || fallbackImage}" alt="${a.titulo}" loading="lazy"></div>
       <div class="pad">
         <span class="kicker">${a.categoria}</span>
         <h3>${a.titulo}</h3>

--- a/post.js
+++ b/post.js
@@ -39,6 +39,7 @@ const apiKey = 'AIzaSyCD9Zu57Qrr7ExMkxXYl0KAbqVTS8ox-PA';
 const titleEl = document.getElementById('post-title');
 const metaEl = document.getElementById('post-meta');
 const contentEl = document.getElementById('post-content');
+const fallbackImage = 'assets/ANXINA-LOGO-NO-BC.webp';
 
 function formatDate(iso) {
   try {
@@ -78,6 +79,11 @@ async function loadPost() {
     const meta = [data.author && data.author.displayName, formatDate(data.published), estimateReadingTime(text)].filter(Boolean).join(' • ');
     metaEl.textContent = meta;
     contentEl.innerHTML = data.content || '';
+    contentEl.querySelectorAll('img').forEach(img => {
+      if (!img.alt || img.alt.trim() === '') {
+        img.alt = data.title || '';
+      }
+    });
   } catch (err) {
     titleEl.textContent = 'Error al cargar el artículo';
     console.error(err);
@@ -98,6 +104,9 @@ async function loadArticles() {
     const data = await res.json();
     articles = (data.items || []).map(item => {
       const text = stripHtml(item.content || '');
+      const div = document.createElement('div');
+      div.innerHTML = item.content || '';
+      const img = div.querySelector('img');
       return {
         id: item.id,
         titulo: item.title || '',
@@ -105,7 +114,8 @@ async function loadArticles() {
         categoria: (item.labels && item.labels[0]) || 'General',
         etiquetas: item.labels ? item.labels.slice(1) : [],
         fecha: item.published ? item.published.split('T')[0] : '',
-        lectura: estimateReadingTimeShort(text)
+        lectura: estimateReadingTimeShort(text),
+        imagen: img ? img.src : fallbackImage
       };
     });
     renderArticles(articles);
@@ -126,7 +136,7 @@ function renderArticles(list) {
     const el = document.createElement('article');
     el.className = 'card';
     el.innerHTML = `
-      <div class="thumb" aria-hidden="true"></div>
+      <figure class="thumb" aria-hidden="true"><img src="${a.imagen || fallbackImage}" alt="${a.titulo}" loading="lazy"></figure>
       <div class="pad">
         <span class="kicker">${a.categoria}</span>
         <h3>${a.titulo}</h3>


### PR DESCRIPTION
## Summary
- Render hero and mini thumbnails with fetched images and titles as alt text
- Add alt attributes to article list images and post content images

## Testing
- `node --check main.js`
- `node --check post.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1d9662a18832bab50675a3d0831e9