### PR TITLE
Sync page title with article titles

### DIFF
--- a/post.js
+++ b/post.js
@@ -75,6 +75,7 @@ async function loadPost() {
     if (!res.ok) throw new Error(res.statusText);
     const data = await res.json();
     titleEl.textContent = data.title || '';
+    document.title = data.title || '';
     const text = stripHtml(data.content || '');
     const meta = [data.author && data.author.displayName, formatDate(data.published), estimateReadingTime(text)].filter(Boolean).join(' • ');
     metaEl.textContent = meta;


### PR DESCRIPTION
## Summary
- Set page title dynamically after fetching article data

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1dcacf29c832b8ae87b9bf144492a