### PR TITLE
Add Bluesky and Discord social bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,10 @@
       "height": 512
     },
     "areaServed": ["Latin America", "Mexico", "Colombia", "Argentina", "Chile", "Perú"],
-    "sameAs": []
+    "sameAs": [
+      "https://discord.gg/anxina",
+      "https://bsky.app/profile/anxina.bsky.social"
+    ]
   }
   </script>
 
@@ -117,45 +120,35 @@
       </div>
       <div class="meta">Edición: Latinoamérica • Español (es-419)</div>
     </div>
-      <div class="social-cards half-card">
-        <div class="up">
+      <div class="half-card">
+        <div class="social-bar">
           <a
-            class="card1"
-            aria-label="Instagram"
-            href="https://www.instagram.com/anxina/"
+            class="social-link bluesky"
+            aria-label="Bluesky"
+            href="https://bsky.app/profile/anxina.bsky.social"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <i class="bi bi-instagram"></i>
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565C.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479c.815 2.736 3.713 3.66 6.383 3.364q.204-.03.415-.056q-.207.033-.415.056c-3.912.58-7.387 2.005-2.83 7.078c5.013 5.19 6.87-1.113 7.823-4.308c.953 3.195 2.05 9.271 7.733 4.308c4.267-4.308 1.172-6.498-2.74-7.078a9 9 0 0 1-.415-.056q.21.026.415.056c2.67.297 5.568-.628 6.383-3.364c.246-.828.624-5.79.624-6.478c0-.69-.139-1.861-.902-2.206c-.659-.298-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8"
+              />
+            </svg>
           </a>
           <a
-            class="card2"
-            aria-label="Twitter"
-            href="https://twitter.com/anxina"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <i class="bi bi-twitter"></i>
-          </a>
-        </div>
-        <div class="down">
-          <a
-            class="card3"
-            aria-label="GitHub"
-            href="https://github.com/tepokato/Anxina"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <i class="bi bi-github"></i>
-          </a>
-          <a
-            class="card4"
+            class="social-link discord"
             aria-label="Discord"
             href="https://discord.gg/anxina"
             target="_blank"
             rel="noopener noreferrer"
           >
-            <i class="bi bi-discord"></i>
+            <svg viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M13.545 2.907a13.2 13.2 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8 8 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.037a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a9 9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085 8 8 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.03.03 0 0 0-.02-.019m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612"
+              />
+            </svg>
           </a>
         </div>
       </div>

--- a/post.html
+++ b/post.html
@@ -85,36 +85,38 @@
       </div>
       <div class="meta">Edición: Latinoamérica • Español (es-419)</div>
     </div>
-      <div class="social-cards half-card">
-      <a
-        class="card1"
-        aria-label="Instagram"
-        href="https://www.instagram.com/anxina/"
-        target="_blank"
-        rel="noopener noreferrer"
-      ><i class="bi bi-instagram"></i></a>
-      <a
-        class="card2"
-        aria-label="Twitter"
-        href="https://twitter.com/anxina"
-        target="_blank"
-        rel="noopener noreferrer"
-      ><i class="bi bi-twitter"></i></a>
-      <a
-        class="card3"
-        aria-label="GitHub"
-        href="https://github.com/tepokato/Anxina"
-        target="_blank"
-        rel="noopener noreferrer"
-      ><i class="bi bi-github"></i></a>
-      <a
-        class="card4"
-        aria-label="Discord"
-        href="https://discord.gg/anxina"
-        target="_blank"
-        rel="noopener noreferrer"
-      ><i class="bi bi-discord"></i></a>
-    </div>
+      <div class="half-card">
+        <div class="social-bar">
+          <a
+            class="social-link bluesky"
+            aria-label="Bluesky"
+            href="https://bsky.app/profile/anxina.bsky.social"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565C.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479c.815 2.736 3.713 3.66 6.383 3.364q.204-.03.415-.056q-.207.033-.415.056c-3.912.58-7.387 2.005-2.83 7.078c5.013 5.19 6.87-1.113 7.823-4.308c.953 3.195 2.05 9.271 7.733 4.308c4.267-4.308 1.172-6.498-2.74-7.078a9 9 0 0 1-.415-.056q.21.026.415.056c2.67.297 5.568-.628 6.383-3.364c.246-.828.624-5.79.624-6.478c0-.69-.139-1.861-.902-2.206c-.659-.298-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8"
+              />
+            </svg>
+          </a>
+          <a
+            class="social-link discord"
+            aria-label="Discord"
+            href="https://discord.gg/anxina"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg viewBox="0 0 16 16" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M13.545 2.907a13.2 13.2 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8 8 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.003.022.021.037a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a9 9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085 8 8 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.03.03 0 0 0-.02-.019m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612"
+              />
+            </svg>
+          </a>
+        </div>
+      </div>
   </footer>
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-modal="true" tabindex="0" aria-label="Aviso de cookies">
     <i class="bi bi-shield-shaded cookie-icon" aria-hidden="true"></i>

--- a/styles.css
+++ b/styles.css
@@ -252,70 +252,67 @@ header.site-header {
 .tags { display: flex; gap: 0.5em; flex-wrap: wrap; }
 .tag { font-size: 0.75em; padding: 0.25em 0.625em; border-radius: 62.4375em; background: rgba(2,132,199,.14); color: var(--muted); border: 0.0625em dashed var(--border); }
 
-.social-cards {
+.social-bar {
   display: flex;
-  flex-direction: column;
-  gap: 0.5em;
+  height: 70px;
+  width: 140px;
 }
 
-.social-cards .up,
-.social-cards .down {
+.social-bar svg {
+  position: absolute;
   display: flex;
-  flex-direction: row;
-  gap: 0.5em;
-}
-
-.card1,
-.card2,
-.card3,
-.card4 {
-  width: 5.625em;
-  height: 5.625em;
-  outline: none;
-  border: none;
-  background: var(--light);
-  box-shadow: rgba(50, 50, 93, 0.25) 0em 0.125em 0.3125em -0.0625em, rgba(0, 0, 0, 0.3) 0em 0.0625em 0.1875em -0.0625em;
-  transition: .2s ease-in-out;
+  width: 60%;
+  height: 100%;
+  font-size: 24px;
+  font-weight: 700;
+  opacity: 1;
+  transition: opacity 0.25s;
+  z-index: 2;
+  padding: 0.25rem;
   cursor: pointer;
+  transform: scale(1);
+}
+
+.social-bar .social-link {
+  position: relative;
   display: flex;
-  justify-content: center;
   align-items: center;
-  font-size: 1.875em;
+  justify-content: center;
+  width: 50%;
+  color: whitesmoke;
+  font-size: 24px;
   text-decoration: none;
+  transition: 0.25s;
+  border-radius: 50px;
 }
 
-.card1 { border-radius: 5.625em 0.3125em 0.3125em 0.3125em; color: #cc39a4; }
-.card2 { border-radius: 0.3125em 5.625em 0.3125em 0.3125em; color: #03A9F4; }
-.card3 { border-radius: 0.3125em 0.3125em 0.3125em 5.625em; color: black; }
-.card4 { border-radius: 0.3125em 0.3125em 5.625em 0.3125em; color: #8c9eff; }
-
-.card1:hover {
-  cursor: pointer;
-  scale: 1.1;
-  background-color: #cc39a4;
+.social-bar .social-link:hover {
+  animation: bounce_613 0.4s linear;
+  color: white;
 }
-.card1:hover .bi { color: white; }
 
-.card2:hover {
-  cursor: pointer;
-  scale: 1.1;
-  background-color: #03A9F4;
+.social-bar .bluesky:hover {
+  background-color: #1185fe;
 }
-.card2:hover .bi { color: white; }
 
-.card3:hover {
-  cursor: pointer;
-  scale: 1.1;
-  background-color: black;
+.social-bar .discord:hover {
+  background-color: #5865f2;
 }
-.card3:hover .bi { color: white; }
 
-.card4:hover {
-  cursor: pointer;
-  scale: 1.1;
-  background-color: #8c9eff;
+@keyframes bounce_613 {
+  40% {
+    transform: scale(1.4);
+  }
+  60% {
+    transform: scale(0.8);
+  }
+  80% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
-.card4:hover .bi { color: white; }
 
 .half-card {
   margin: 1.25em 0;


### PR DESCRIPTION
## Summary
- replace legacy social links with Bluesky and Discord icons
- expose Bluesky and Discord profiles in JSON-LD metadata
- add modern hover animation for new social bar

## Testing
- `npx prettier --check index.html post.html styles.css` *(fails: Code style issues found in 3 files)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e1beb428832b8565c9aa4156b464