### PR TITLE
Add toggleable search bar with icon button

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,10 +65,12 @@
       </nav>
 
       <div class="actions">
-        <label class="search" aria-label="Buscar artículos">
-          <i class="bi bi-search search-icon"></i>
-          <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" />
-        </label>
+        <div class="search">
+          <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
+            <i class="bi bi-search"></i>
+          </button>
+          <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" />
+        </div>
         <label class="theme-switch">
           <input id="themeToggle" class="toggle-checkbox" type="checkbox" aria-label="Cambiar a modo oscuro" />
           <div class="toggle-slot">

--- a/main.js
+++ b/main.js
@@ -157,6 +157,32 @@ links.forEach(link => link.addEventListener('click', (e) => {
 }));
 
 const q = document.getElementById('q');
+const searchWrap = document.querySelector('.search');
+const searchBtn = document.getElementById('searchBtn');
+
+searchBtn.addEventListener('click', e => {
+  e.preventDefault();
+  searchWrap.classList.toggle('active');
+  const active = searchWrap.classList.contains('active');
+  q.hidden = !active;
+  searchBtn.setAttribute('aria-expanded', active);
+  if (!q.hidden) q.focus();
+});
+
+document.addEventListener('click', e => {
+  if (!searchWrap.contains(e.target)) {
+    searchWrap.classList.remove('active');
+    q.hidden = true;
+    searchBtn.setAttribute('aria-expanded', 'false');
+  }
+});
+
+q.addEventListener('search', () => {
+  searchWrap.classList.remove('active');
+  q.hidden = true;
+  searchBtn.setAttribute('aria-expanded', 'false');
+});
+
 q.addEventListener('input', () => {
   const term = q.value.trim().toLowerCase();
   const current = document.querySelector('.nav-links [aria-current="page"]');

--- a/post.html
+++ b/post.html
@@ -37,10 +37,12 @@
       </nav>
 
       <div class="actions">
-        <label class="search" aria-label="Buscar artículos">
-          <i class="bi bi-search search-icon"></i>
-          <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" />
-        </label>
+        <div class="search">
+          <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
+            <i class="bi bi-search"></i>
+          </button>
+          <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" />
+        </div>
         <label class="theme-switch">
           <input id="themeToggle" class="toggle-checkbox" type="checkbox" aria-label="Cambiar a modo oscuro" />
           <div class="toggle-slot">

--- a/post.js
+++ b/post.js
@@ -170,6 +170,32 @@ links.forEach(link => link.addEventListener('click', (e) => {
 }));
 
 const q = document.getElementById('q');
+const searchWrap = document.querySelector('.search');
+const searchBtn = document.getElementById('searchBtn');
+
+searchBtn.addEventListener('click', e => {
+  e.preventDefault();
+  searchWrap.classList.toggle('active');
+  const active = searchWrap.classList.contains('active');
+  q.hidden = !active;
+  searchBtn.setAttribute('aria-expanded', active);
+  if (!q.hidden) q.focus();
+});
+
+document.addEventListener('click', e => {
+  if (!searchWrap.contains(e.target)) {
+    searchWrap.classList.remove('active');
+    q.hidden = true;
+    searchBtn.setAttribute('aria-expanded', 'false');
+  }
+});
+
+q.addEventListener('search', () => {
+  searchWrap.classList.remove('active');
+  q.hidden = true;
+  searchBtn.setAttribute('aria-expanded', 'false');
+});
+
 q.addEventListener('input', () => {
   const term = q.value.trim().toLowerCase();
   const current = document.querySelector('.nav-links [aria-current="page"]');

--- a/styles.css
+++ b/styles.css
@@ -122,25 +122,35 @@ header.site-header {
 
 .search {
   display: flex;
-  line-height: 1.75em;
   align-items: center;
-  position: relative;
-  max-width: 11.875em;
+  gap: 0.5em;
+}
+
+.search-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5em;
+  height: 2.5em;
+  border-radius: 50%;
+  background: var(--panel);
+  border: 0.0625em solid var(--border);
+  cursor: pointer;
 }
 
 .search-input {
-  width: 100%;
-  height: 2.8125em;
-  padding-left: 2.5rem;
+  display: inline-block;
+  width: 0;
+  height: 2.5em;
+  padding: 0 0.75em;
   box-shadow: 0 0 0 0.0938em var(--border), 0 0 1.5625em -1.0625em #000;
   border: 0;
   border-radius: 0.75em;
   background-color: var(--panel);
   outline: none;
   color: var(--text);
-  transition: all 0.25s cubic-bezier(0.19, 1, 0.22, 1);
-  cursor: text;
-  z-index: 0;
+  transition: width 0.25s ease, opacity 0.25s ease;
+  opacity: 0;
 }
 
 .search-input::placeholder {
@@ -148,7 +158,7 @@ header.site-header {
 }
 
 .search-input:hover {
-  box-shadow: 0 0 0 0.1562em var(--border), 0em 0em 1.5625em -0.9375em #000;
+  box-shadow: 0 0 0 0.1562em var(--border), 0 0 1.5625em -0.9375em #000;
 }
 
 .search-input:active {
@@ -159,16 +169,9 @@ header.site-header {
   box-shadow: 0 0 0 0.1562em var(--border);
 }
 
-.search-icon {
-  position: absolute;
-  left: 1rem;
-  width: 1rem;
-  height: 1rem;
-  pointer-events: none;
-  z-index: 1;
-  color: var(--muted);
-  display: inline-block;
-    font-size: 1rem;
+.search.active .search-input {
+  width: 11.875em;
+  opacity: 1;
 }
 
 /* Theme toggle switch */


### PR DESCRIPTION
## Summary
- Replace search label with button + expandable input in index and post headers.
- Style search button and input for hidden-by-default expansion.
- Add JS logic to toggle search field visibility with outside-click handling and ARIA updates.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24ba75df4832b89bbabfc13e8dc37