### PR TITLE
Align skip link styling with back-to-top

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
 </head>
 <body>
-  <a href="#contenido" class="skip-link" aria-label="Saltar al contenido">
+  <a href="#contenido" class="skip-link show" aria-label="Saltar al contenido">
     <i class="bi bi-arrow-down"></i>
   </a>
   <header class="site-header">

--- a/main.js
+++ b/main.js
@@ -26,9 +26,9 @@ function updateThemeToggle(theme) {
 const skip = document.querySelector('.skip-link');
 if (skip) {
   window.addEventListener('scroll', () => {
-    if (window.scrollY > 0) skip.classList.add('hidden');
+    if (window.scrollY > 0) skip.classList.remove('show');
   }, { once: true });
-  skip.addEventListener('click', () => skip.classList.add('hidden'));
+  skip.addEventListener('click', () => skip.classList.remove('show'));
 }
 
 let articles = [];

--- a/post.html
+++ b/post.html
@@ -14,7 +14,7 @@
   <script src="https://code.iconify.design/2/2.2.1/iconify.min.js"></script>
 </head>
 <body>
-  <a href="#contenido" class="skip-link" aria-label="Saltar al contenido">
+  <a href="#contenido" class="skip-link show" aria-label="Saltar al contenido">
     <i class="bi bi-arrow-down"></i>
   </a>
   <header class="site-header">

--- a/post.js
+++ b/post.js
@@ -26,9 +26,9 @@ function updateThemeToggle(theme) {
 const skip = document.querySelector('.skip-link');
 if (skip) {
   window.addEventListener('scroll', () => {
-    if (window.scrollY > 0) skip.classList.add('hidden');
+    if (window.scrollY > 0) skip.classList.remove('show');
   }, { once: true });
-  skip.addEventListener('click', () => skip.classList.add('hidden'));
+  skip.addEventListener('click', () => skip.classList.remove('show'));
 }
 
 const params = new URLSearchParams(window.location.search);

--- a/styles.css
+++ b/styles.css
@@ -46,22 +46,34 @@ a:hover { text-decoration: underline; }
 
 .skip-link {
   position: fixed;
-  top: 1rem;
-  left: 1rem;
+  top: 1.25em;
+  left: 1.25em;
   z-index: 1000;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2.5em;
-  height: 2.5em;
-  background: var(--accent);
-  color: var(--light);
+  width: 3em;
+  height: 3em;
+  border: none;
   border-radius: 50%;
+  background: linear-gradient(270deg, #16423C, #6A9C89);
+  background-size: 600% 600%;
+  color: #E9EFEC;
+  box-shadow: var(--shadow);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s ease;
+  animation: gradientMove 8s ease infinite;
 }
-.skip-link.hidden {
-  display: none;
+.skip-link:hover,
+.skip-link:active {
+  background: linear-gradient(270deg, #6A9C89, #C4DAD2);
 }
-[data-theme="dark"] .skip-link { color: var(--bg); }
+.skip-link.show {
+  opacity: 1;
+  pointer-events: auto;
+}
 
 .container { max-width: 70em; margin: 0 auto; padding: 0 1.25em; }
 


### PR DESCRIPTION
## Summary
- Restyled the skip link to match the back-to-top button with gradient background, box shadow, animation, and hover/active states.
- Added `.show` visibility helper and adjusted HTML to use it by default.
- Updated scripts to remove the `show` class on scroll or click for consistency.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2654dbf08832bad04ffde38659856