### PR TITLE
Align skip-link and back-to-top arrow icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 </head>
 <body>
   <a href="#contenido" class="skip-link show" aria-label="Saltar al contenido">
-    <i class="bi bi-arrow-down"></i>
+    <i class="bi bi-arrow-down-short"></i>
   </a>
   <header class="site-header">
     <div class="container nav" role="navigation" aria-label="Principal">

--- a/post.html
+++ b/post.html
@@ -15,7 +15,7 @@
 </head>
 <body>
   <a href="#contenido" class="skip-link show" aria-label="Saltar al contenido">
-    <i class="bi bi-arrow-down"></i>
+    <i class="bi bi-arrow-down-short"></i>
   </a>
   <header class="site-header">
     <div class="container nav" role="navigation" aria-label="Principal">


### PR DESCRIPTION
## Summary
- Use `bi-arrow-down-short` for skip-link icons on index and post pages
- Keep existing `bi-arrow-up-short` back-to-top icons for visual consistency

## Testing
- `npx prettier --check index.html post.html` *(fails: Code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a26957e4c4832bbfa8bc501db6a44b