### PR TITLE
Integrate NES.css styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
   }
   </script>
 
+  <link rel="stylesheet" href="https://unpkg.com/nes.css@2.3.0/css/nes.min.css" />
+  <link href="https://fonts.googleapis.com/css?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 </head>
@@ -113,7 +115,7 @@
         <form id="newsletterForm" action="#">
           <div class="field">
             <input class="input" type="email" name="email" placeholder="tu@correo.com" aria-label="Correo electrónico" required />
-            <button class="btn" type="submit">Suscribirme</button>
+            <button class="nes-btn is-primary" type="submit">Suscribirme</button>
           </div>
         </form>
         <small id="newsletterMsg" aria-live="polite" class="muted"></small>
@@ -168,7 +170,7 @@
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-modal="true" tabindex="0" aria-label="Aviso de cookies">
     <i class="bi bi-shield-shaded cookie-icon" aria-hidden="true"></i>
     <p>Usamos cookies para mejorar la experiencia del usuario.<i class="bi bi-box-arrow-in-up-right"></i></p>
-    <button id="cookie-accept" class="cookie-btn">Aceptar</button>
+    <button id="cookie-accept" class="nes-btn is-primary">Aceptar</button>
   </div>
   <button id="backToTop" class="back-to-top" aria-label="Volver arriba">
     <i class="bi bi-arrow-up-short"></i>

--- a/post.html
+++ b/post.html
@@ -9,6 +9,8 @@
   <link rel="icon" type="image/png" sizes="48x48" href="icons/icon-48x48.png">
   <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="192x192" href="icons/android-chrome-192x192.png">
+  <link rel="stylesheet" href="https://unpkg.com/nes.css@2.3.0/css/nes.min.css" />
+  <link href="https://fonts.googleapis.com/css?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 </head>
@@ -77,7 +79,7 @@
         <form id="newsletterForm" action="#">
           <div class="field">
             <input class="input" type="email" name="email" placeholder="tu@correo.com" aria-label="Correo electrónico" required />
-            <button class="btn" type="submit">Suscribirme</button>
+            <button class="nes-btn is-primary" type="submit">Suscribirme</button>
           </div>
         </form>
         <small id="newsletterMsg" aria-live="polite" class="muted"></small>
@@ -131,7 +133,7 @@
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-modal="true" tabindex="0" aria-label="Aviso de cookies">
     <i class="bi bi-shield-shaded cookie-icon" aria-hidden="true"></i>
     <p>Usamos cookies para mejorar la experiencia del usuario.</p>
-    <button id="cookie-accept" class="cookie-btn">Aceptar</button>
+    <button id="cookie-accept" class="nes-btn is-primary">Aceptar</button>
   </div>
   <button id="backToTop" class="back-to-top" aria-label="Volver arriba">
     <i class="bi bi-arrow-up-short"></i>

--- a/search.html
+++ b/search.html
@@ -9,6 +9,8 @@
   <link rel="icon" type="image/png" sizes="48x48" href="icons/icon-48x48.png">
   <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="192x192" href="icons/android-chrome-192x192.png">
+  <link rel="stylesheet" href="https://unpkg.com/nes.css@2.3.0/css/nes.min.css" />
+  <link href="https://fonts.googleapis.com/css?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 </head>
@@ -80,7 +82,7 @@
         <form id="newsletterForm" action="#">
           <div class="field">
             <input class="input" type="email" name="email" placeholder="tu@correo.com" aria-label="Correo electrónico" required/>
-            <button class="btn" type="submit">Suscribirme</button>
+            <button class="nes-btn is-primary" type="submit">Suscribirme</button>
           </div>
         </form>
         <small id="newsletterMsg" aria-live="polite" class="muted"></small>
@@ -135,7 +137,7 @@
   <div id="cookie-banner" class="cookie-banner" role="dialog" aria-modal="true" tabindex="0" aria-label="Aviso de cookies">
     <i class="bi bi-shield-shaded cookie-icon" aria-hidden="true"></i>
     <p>Usamos cookies para mejorar la experiencia del usuario.</p>
-    <button id="cookie-accept" class="cookie-btn">Aceptar</button>
+    <button id="cookie-accept" class="nes-btn is-primary">Aceptar</button>
   </div>
   <button id="backToTop" class="back-to-top" aria-label="Volver arriba">
     <i class="bi bi-arrow-up-short"></i>

--- a/styles.css
+++ b/styles.css
@@ -109,31 +109,6 @@ header.site-header {
 .chip[aria-current="page"] { color: var(--text); border-color: var(--accent); }
 
 .actions { display: flex; align-items: center; gap: 0.75em; }
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75em 1.25em;
-  border: none;
-  border-radius: 0.75em;
-  font-weight: 700;
-  color: #E9EFEC;
-  background: linear-gradient(270deg, #16423C, #6A9C89);
-  background-size: 600% 600%;
-  animation: gradientMove 8s ease infinite;
-  cursor: pointer;
-  transition: transform .2s, box-shadow .2s;
-}
-.btn:hover,
-.btn:active {
-  background: linear-gradient(270deg, #6A9C89, #C4DAD2);
-  transform: translateY(-0.125em);
-  box-shadow: 0 0.25em 0.75em rgba(0,0,0,.3);
-}
-.btn:focus {
-  outline: 0.125em solid #E9EFEC;
-  outline-offset: 0.125em;
-}
 
 .search {
   display: flex;
@@ -460,21 +435,8 @@ header.site-header {
 .cookie-banner p {
   margin: 0;
 }
-.cookie-btn {
-  justify-self: end;
-  padding: 0.5em 1em;
-  background: var(--accent);
-  color: var(--light);
-  border: none;
-  border-radius: 0.75em;
-  font-weight: 700;
-  cursor: pointer;
-}
-.cookie-btn:focus {
-  outline: 0.125em solid var(--accent-2);
-}
 [data-theme="dark"] .cookie-icon,
-[data-theme="dark"] .cookie-btn { color: var(--bg); }
+[data-theme="dark"] #cookie-accept { color: var(--bg); }
 
 footer {
   background: rgba(var(--panel-rgb), 0.7);


### PR DESCRIPTION
## Summary
- Load NES.css and Press Start 2P font across all pages
- Restyle newsletter and cookie consent buttons using NES retro design
- Remove unused custom button styles and update dark-theme cookie banner colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c8d1408bb0832bb204febf8dffc067