### PR TITLE
Add WordPress Netlify function

### DIFF
--- a/netlify/functions/wordpress.js
+++ b/netlify/functions/wordpress.js
@@ -1,0 +1,51 @@
+exports.handler = async function(event, context) {
+  try {
+    const baseUrl = process.env.WP_BASE_URL;
+    if (!baseUrl) {
+      return {
+        statusCode: 500,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'max-age=60'
+        },
+        body: 'Missing WordPress base URL'
+      };
+    }
+
+    const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+    const url = `${normalizedBaseUrl}/wp-json/wp/v2/posts`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      return {
+        statusCode: response.status,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'max-age=60'
+        },
+        body: `Error fetching posts: ${response.statusText}`
+      };
+    }
+
+    const body = await response.text();
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'max-age=60'
+      },
+      body
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'max-age=60'
+      },
+      body: 'Internal server error'
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add a Netlify function that fetches posts from the configured WordPress site via `WP_BASE_URL`
- mirror the Blogger function's CORS and caching headers while handling missing config and fetch errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8d7ae3ef8832baec5c853e53572fb