### PR TITLE
Add configurable WordPress client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+wp-config.js

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ These variables are optional unless you wire the Blogger endpoint into the UI.
 2. Set the required environment variables for your local Netlify environment. You can use `netlify env:set WP_BASE_URL https://example.com` (and the optional auth variables) so `netlify dev` can inject them when serving functions.
 3. Start the development server: `netlify dev`. This serves the static front-end from the project root and proxies calls to the serverless functions.
 
+### Running without Netlify functions
+The front-end can also talk directly to the WordPress REST API without relying on Netlify. This is useful when you just want to edit the UI locally or when the API already exposes public data.
+
+1. Copy the sample `wp-config.js` file and update it with your WordPress endpoint:
+
+   ```js
+   window.WP_CONFIG = {
+     apiUrl: 'https://your-wordpress-site.com/wp-json/wp/v2/posts?_embed=1',
+     username: 'optional_user',
+     password: 'optional_password'
+   };
+   ```
+
+   The credentials are optional. If you do not need Basic Auth or WordPress Application Passwords, leave both fields empty. The file is listed in `.gitignore` so you can safely store local credentials without committing them.
+2. Serve the site with any static file server. For example, install [serve](https://www.npmjs.com/package/serve) and run `npx serve .`, or use the static server that ships with your editor.
+3. Open the reported URL (typically `http://localhost:3000`) and the pages (`index.html`, `post.html`, `search.html`) will use your configuration when fetching posts.
+
 ## Deploying to Netlify
 Netlify automatically bundles any functions stored in `netlify/functions/*.js`. To deploy this repository:
 

--- a/index.html
+++ b/index.html
@@ -174,6 +174,7 @@
     <i class="bi bi-arrow-up-short"></i>
   </button>
 
+  <script src="wp-config.js"></script>
   <script src="main.js" defer></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -12,7 +12,10 @@ let articles = [];
 
 const articlesEl = document.getElementById('articles');
 const fallbackImage = 'assets/ANXINA-LOGO-NO-BC.webp';
-const WP_API = '/.netlify/functions/wordpress';
+const { apiUrl = '/.netlify/functions/wordpress', username, password } = window.WP_CONFIG || {};
+const authOptions = username ? {
+  headers: { Authorization: `Basic ${btoa(`${username}:${password ?? ''}`)}` }
+} : undefined;
 const WP_CACHE_KEY = 'wordpressData';
 const WP_CACHE_TIME_KEY = 'wordpressDataTime';
 const CACHE_MS = 60000;
@@ -27,7 +30,7 @@ function getCachedData() {
 }
 
 async function updateCache() {
-  const res = await fetch(WP_API);
+  const res = await fetch(apiUrl, authOptions);
   if (!res.ok) throw new Error(res.statusText);
   const data = await res.json();
   try {

--- a/post.html
+++ b/post.html
@@ -136,6 +136,7 @@
   <button id="backToTop" class="back-to-top" aria-label="Volver arriba">
     <i class="bi bi-arrow-up-short"></i>
   </button>
+  <script src="wp-config.js"></script>
   <script src="post.js" defer></script>
 </body>
 </html>

--- a/post.js
+++ b/post.js
@@ -15,7 +15,10 @@ const titleEl = document.getElementById('post-title');
 const metaEl = document.getElementById('post-meta');
 const contentEl = document.getElementById('post-content');
 const fallbackImage = 'assets/ANXINA-LOGO-NO-BC.webp';
-const WP_API = '/.netlify/functions/wordpress';
+const { apiUrl = '/.netlify/functions/wordpress', username, password } = window.WP_CONFIG || {};
+const authOptions = username ? {
+  headers: { Authorization: `Basic ${btoa(`${username}:${password ?? ''}`)}` }
+} : undefined;
 const WP_CACHE_KEY = 'wordpressData';
 const WP_CACHE_TIME_KEY = 'wordpressDataTime';
 const CACHE_MS = 60000;
@@ -30,7 +33,7 @@ function getCachedData() {
 }
 
 async function updateCache() {
-  const res = await fetch(WP_API);
+  const res = await fetch(apiUrl, authOptions);
   if (!res.ok) throw new Error(res.statusText);
   const data = await res.json();
   try {

--- a/search.html
+++ b/search.html
@@ -140,6 +140,7 @@
   <button id="backToTop" class="back-to-top" aria-label="Volver arriba">
     <i class="bi bi-arrow-up-short"></i>
   </button>
+  <script src="wp-config.js"></script>
   <script src="search.js" defer></script>
 </body>
 </html>

--- a/search.js
+++ b/search.js
@@ -17,7 +17,10 @@ const params = new URLSearchParams(window.location.search);
 const initialTerm = (params.get('q') || '').trim();
 const q = document.getElementById('q');
 if (q && initialTerm) q.value = initialTerm;
-const WP_API = '/.netlify/functions/wordpress';
+const { apiUrl = '/.netlify/functions/wordpress', username, password } = window.WP_CONFIG || {};
+const authOptions = username ? {
+  headers: { Authorization: `Basic ${btoa(`${username}:${password ?? ''}`)}` }
+} : undefined;
 const WP_CACHE_KEY = 'wordpressData';
 const WP_CACHE_TIME_KEY = 'wordpressDataTime';
 const CACHE_MS = 60000;
@@ -32,7 +35,7 @@ function getCachedData() {
 }
 
 async function updateCache() {
-  const res = await fetch(WP_API);
+  const res = await fetch(apiUrl, authOptions);
   if (!res.ok) throw new Error(res.statusText);
   const data = await res.json();
   try {

--- a/wp-config.js
+++ b/wp-config.js
@@ -1,0 +1,5 @@
+window.WP_CONFIG = window.WP_CONFIG || {
+  apiUrl: 'https://example.com/wp-json/wp/v2/posts?_embed=1',
+  username: '',
+  password: ''
+};


### PR DESCRIPTION
## Summary
- add a `wp-config.js` bootstrap file for configuring the WordPress REST endpoint locally and ignore it in git
- load the config before page scripts and use its values (including optional basic auth) when fetching posts
- document how to run the site locally without Netlify by filling out the config file

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c96eb28324832bb2d41903eefa844b