### PR TITLE
Update WordPress API fallback and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ window.WP_CONFIG = {
 
 The credentials are optional. If you do not need Basic Auth or WordPress Application Passwords, leave both fields empty. The file is listed in `.gitignore` so you can safely store local credentials without committing them.
 
+If you leave `apiUrl` empty, the scripts fall back to the public [WordPress News API](https://wordpress.org/news/wp-json/wp/v2/posts?_embed=1) so you can demo the site without configuring Netlify Functions or a custom backend.
+
 ## Running locally
 1. Update `wp-config.js` with your WordPress REST API URL (as shown above).
 2. Serve the site with any static file server. For example, install [serve](https://www.npmjs.com/package/serve) and run `npx serve .`, or use the static server that ships with your editor.

--- a/main.js
+++ b/main.js
@@ -12,12 +12,16 @@ let articles = [];
 
 const articlesEl = document.getElementById('articles');
 const fallbackImage = 'assets/ANXINA-LOGO-NO-BC.webp';
-const defaultConfig = {
-  apiUrl: 'https://example.com/wp-json/wp/v2/posts?_embed=1',
-  username: '',
-  password: ''
-};
-const { apiUrl, username, password } = { ...defaultConfig, ...(window.WP_CONFIG || {}) };
+// Prefer the runtime configuration but fall back to a public WordPress REST endpoint
+// so the static build keeps working without Netlify Functions.
+const fallbackApiUrl = 'https://wordpress.org/news/wp-json/wp/v2/posts?_embed=1';
+const runtimeConfig = window.WP_CONFIG || {};
+const apiUrl = runtimeConfig.apiUrl || fallbackApiUrl;
+const username = runtimeConfig.username || '';
+const password = runtimeConfig.password || '';
+if (!runtimeConfig.apiUrl) {
+  console.warn('WP_CONFIG.apiUrl is not defined; using WordPress News API fallback.');
+}
 const authOptions = username ? {
   headers: { Authorization: `Basic ${btoa(`${username}:${password ?? ''}`)}` }
 } : undefined;
@@ -226,7 +230,7 @@ function mapWordPressPost(post) {
 
   const featured = post?._embedded?.['wp:featuredmedia']?.[0];
   const image = featured?.source_url || featured?.media_details?.sizes?.medium?.source_url || '';
-  const author = stripHtml(post?._embedded?.author?.[0]?.name || '').trim();
+  const autor = stripHtml(post?._embedded?.author?.[0]?.name || '').trim();
   const fecha = post?.date || '';
   const readingSource = contentText || excerptText || title;
 

--- a/post.js
+++ b/post.js
@@ -15,12 +15,16 @@ const titleEl = document.getElementById('post-title');
 const metaEl = document.getElementById('post-meta');
 const contentEl = document.getElementById('post-content');
 const fallbackImage = 'assets/ANXINA-LOGO-NO-BC.webp';
-const defaultConfig = {
-  apiUrl: 'https://example.com/wp-json/wp/v2/posts?_embed=1',
-  username: '',
-  password: ''
-};
-const { apiUrl, username, password } = { ...defaultConfig, ...(window.WP_CONFIG || {}) };
+// Prefer the runtime configuration but fall back to a public WordPress REST endpoint
+// so the static build keeps working without Netlify Functions.
+const fallbackApiUrl = 'https://wordpress.org/news/wp-json/wp/v2/posts?_embed=1';
+const runtimeConfig = window.WP_CONFIG || {};
+const apiUrl = runtimeConfig.apiUrl || fallbackApiUrl;
+const username = runtimeConfig.username || '';
+const password = runtimeConfig.password || '';
+if (!runtimeConfig.apiUrl) {
+  console.warn('WP_CONFIG.apiUrl is not defined; using WordPress News API fallback.');
+}
 const authOptions = username ? {
   headers: { Authorization: `Basic ${btoa(`${username}:${password ?? ''}`)}` }
 } : undefined;
@@ -154,7 +158,7 @@ function mapWordPressPost(post) {
 
   const featured = post?._embedded?.['wp:featuredmedia']?.[0];
   const image = featured?.source_url || featured?.media_details?.sizes?.medium?.source_url || '';
-  const author = stripHtml(post?._embedded?.author?.[0]?.name || '').trim();
+  const autor = stripHtml(post?._embedded?.author?.[0]?.name || '').trim();
   const fecha = post?.date || '';
   const readingSource = contentText || excerptText || title;
 

--- a/search.js
+++ b/search.js
@@ -17,12 +17,16 @@ const params = new URLSearchParams(window.location.search);
 const initialTerm = (params.get('q') || '').trim();
 const q = document.getElementById('q');
 if (q && initialTerm) q.value = initialTerm;
-const defaultConfig = {
-  apiUrl: 'https://example.com/wp-json/wp/v2/posts?_embed=1',
-  username: '',
-  password: ''
-};
-const { apiUrl, username, password } = { ...defaultConfig, ...(window.WP_CONFIG || {}) };
+// Prefer the runtime configuration but fall back to a public WordPress REST endpoint
+// so the static build keeps working without Netlify Functions.
+const fallbackApiUrl = 'https://wordpress.org/news/wp-json/wp/v2/posts?_embed=1';
+const runtimeConfig = window.WP_CONFIG || {};
+const apiUrl = runtimeConfig.apiUrl || fallbackApiUrl;
+const username = runtimeConfig.username || '';
+const password = runtimeConfig.password || '';
+if (!runtimeConfig.apiUrl) {
+  console.warn('WP_CONFIG.apiUrl is not defined; using WordPress News API fallback.');
+}
 const authOptions = username ? {
   headers: { Authorization: `Basic ${btoa(`${username}:${password ?? ''}`)}` }
 } : undefined;
@@ -210,7 +214,7 @@ function mapWordPressPost(post) {
 
   const featured = post?._embedded?.['wp:featuredmedia']?.[0];
   const image = featured?.source_url || featured?.media_details?.sizes?.medium?.source_url || '';
-  const author = stripHtml(post?._embedded?.author?.[0]?.name || '').trim();
+  const autor = stripHtml(post?._embedded?.author?.[0]?.name || '').trim();
   const fecha = post?.date || '';
   const readingSource = contentText || excerptText || title;
 

--- a/wp-config.js
+++ b/wp-config.js
@@ -1,5 +1,7 @@
 window.WP_CONFIG = window.WP_CONFIG || {
-  apiUrl: 'https://example.com/wp-json/wp/v2/posts?_embed=1',
+  // Provide your WordPress REST endpoint (e.g. https://your-site.com/wp-json/wp/v2/posts?_embed=1).
+  // Leaving apiUrl empty lets the app fall back to the public WordPress News API for demos.
+  apiUrl: '',
   username: '',
   password: ''
 };


### PR DESCRIPTION
## Summary
- use a public WordPress REST endpoint as the fallback when no runtime apiUrl is provided
- document the new behaviour in wp-config.js and README, including the public demo endpoint
- ensure mapped posts use the autor property without triggering ReferenceErrors

## Testing
- npm test
- verified index, post, and search pages load content via Playwright scripts against the fallback API

------
https://chatgpt.com/codex/tasks/task_e_68ca29c47408832b97db81ee7c71319a