### PR TITLE
Add default Todas filter chip across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
       </button>
 
       <nav id="siteFilters" class="nav-links" aria-label="Categorías">
+        <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
         <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
         <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
         <a class="chip" href="#" data-filter="startups">Startups</a>

--- a/main.js
+++ b/main.js
@@ -282,11 +282,24 @@ loadArticles();
 setInterval(updateCache, CACHE_MS);
 
 const links = document.querySelectorAll('.nav-links [data-filter]');
+
+function setActiveFilter(activeLink) {
+  links.forEach(link => {
+    if (link === activeLink) {
+      link.setAttribute('aria-current', 'page');
+    } else {
+      link.removeAttribute('aria-current');
+    }
+  });
+}
+
+const defaultLink = document.querySelector('.nav-links [data-filter="todas"]');
+if (defaultLink) setActiveFilter(defaultLink);
+
 links.forEach(link => link.addEventListener('click', (e) => {
   e.preventDefault();
   const f = link.getAttribute('data-filter') || 'todas';
-  links.forEach(l => l.removeAttribute('aria-current'));
-  link.setAttribute('aria-current', 'page');
+  setActiveFilter(link);
   const filtered = filterArticlesByCategory(f);
   renderArticles(filtered);
   if (navControls) navControls.close();

--- a/post.html
+++ b/post.html
@@ -34,6 +34,7 @@
       </button>
 
       <nav id="siteFilters" class="nav-links" aria-label="Categorías">
+        <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
         <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
         <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
         <a class="chip" href="#" data-filter="startups">Startups</a>

--- a/post.js
+++ b/post.js
@@ -17,8 +17,24 @@ if (skip) {
   skip.addEventListener('click', () => skip.classList.remove('show'));
 }
 
-const navLinks = document.querySelectorAll('.nav-links a');
-navLinks.forEach(link => link.addEventListener('click', () => {
+const navLinks = document.querySelectorAll('.nav-links [data-filter]');
+
+function setActiveFilter(activeLink) {
+  navLinks.forEach(link => {
+    if (link === activeLink) {
+      link.setAttribute('aria-current', 'page');
+    } else {
+      link.removeAttribute('aria-current');
+    }
+  });
+}
+
+const defaultNavLink = document.querySelector('.nav-links [data-filter="todas"]');
+if (defaultNavLink) setActiveFilter(defaultNavLink);
+
+navLinks.forEach(link => link.addEventListener('click', (e) => {
+  e.preventDefault();
+  setActiveFilter(link);
   if (navControls) navControls.close();
 }));
 

--- a/search.html
+++ b/search.html
@@ -34,6 +34,7 @@
       </button>
 
       <nav id="siteFilters" class="nav-links" aria-label="Categorías">
+        <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
         <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
         <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
         <a class="chip" href="#" data-filter="startups">Startups</a>

--- a/search.js
+++ b/search.js
@@ -18,6 +18,7 @@ if (skip) {
 }
 
 let articles = [];
+let searchResults = [];
 
 const articlesEl = document.getElementById('articles');
 const resultsMsg = document.getElementById('resultsMsg');
@@ -93,6 +94,7 @@ function performSearch() {
         (a.titulo + ' ' + a.resumen + ' ' + a.etiquetas.join(' ')).toLowerCase().includes(term)
       )
     : [];
+  searchResults = results;
   if (!results.length) {
     resultsMsg.hidden = false;
     articlesEl.innerHTML = '';
@@ -266,18 +268,36 @@ loadArticles();
 setInterval(updateCache, CACHE_MS);
 
 const links = document.querySelectorAll('.nav-links [data-filter]');
+
+function setActiveFilter(activeLink) {
+  links.forEach(link => {
+    if (link === activeLink) {
+      link.setAttribute('aria-current', 'page');
+    } else {
+      link.removeAttribute('aria-current');
+    }
+  });
+}
+
+const defaultLink = document.querySelector('.nav-links [data-filter="todas"]');
+if (defaultLink) setActiveFilter(defaultLink);
+
 links.forEach(link => link.addEventListener('click', (e) => {
   e.preventDefault();
   const f = link.getAttribute('data-filter') || 'todas';
-  links.forEach(l => l.removeAttribute('aria-current'));
-  link.setAttribute('aria-current', 'page');
-  const results = filterArticlesByCategory(f);
-  if (!results.length) {
-    resultsMsg.hidden = false;
-    articlesEl.innerHTML = '';
+  setActiveFilter(link);
+  if (f === 'todas') {
+    performSearch();
   } else {
-    resultsMsg.hidden = true;
-    renderArticles(results);
+    const baseList = searchResults.length ? searchResults : articles;
+    const results = filterArticlesByCategory(f, baseList);
+    if (!results.length) {
+      resultsMsg.hidden = false;
+      articlesEl.innerHTML = '';
+    } else {
+      resultsMsg.hidden = true;
+      renderArticles(results);
+    }
   }
   if (navControls) navControls.close();
 }));

--- a/styles.css
+++ b/styles.css
@@ -107,7 +107,11 @@ header.site-header {
   display: inline-flex; align-items: center; gap: 0.5em; padding: 0.5em 0.75em; border: 0.0625em solid var(--border); border-radius: 62.4375em; background: var(--panel);
   font-weight: 600; font-size: 0.875em; color: var(--muted);
 }
-.chip[aria-current="page"] { color: var(--text); border-color: var(--accent); }
+.chip[aria-current="page"] {
+  color: var(--bg);
+  border-color: var(--accent);
+  background: var(--accent);
+}
 
 .actions { display: flex; align-items: center; gap: 0.75em; margin-left: auto; }
 .nav-toggle {


### PR DESCRIPTION
## Summary
- add a leading "Todas" filter chip to the navigation on every page and mark it as active by default
- initialize filter handling in each script so the "Todas" chip is set on load and resets the list when clicked
- update the chip active styling to keep the selected state visually distinct

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cafcafba68832bb2abd54c5235fb77