### PR TITLE
Allow navigation header height to grow when content wraps

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -87,7 +87,7 @@ header.site-header {
   border-bottom: 0.0625em solid var(--border);
 }
 .nav {
-  display: flex; align-items: center; gap: 1em; height: 4em;
+  display: flex; align-items: center; gap: 1em; min-height: 4em;
   justify-content: space-between;
   position: relative;
 }


### PR DESCRIPTION
## Summary
- replace the navigation bar's fixed height with a minimum height so the header can expand when items wrap

## Testing
- Manually reloaded the site at <=40em width to confirm controls remain within the header background


------
https://chatgpt.com/codex/tasks/task_e_68cb06101cc4832b9de32a9342fb4409