### PR TITLE
Refine mobile navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,40 +56,42 @@
         </span>
       </a>
 
-      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="siteFilters" aria-haspopup="true">
-        <i class="bi bi-funnel" aria-hidden="true"></i>
-        <span>Categorías</span>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="siteMenu" aria-haspopup="true">
+        <i class="bi bi-list" aria-hidden="true"></i>
+        <span>Menú y filtros</span>
       </button>
 
-      <nav id="siteFilters" class="nav-links" aria-label="Categorías">
-        <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
-        <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
-        <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
-        <a class="chip" href="#" data-filter="startups">Startups</a>
-        <a class="chip" href="#" data-filter="opinion">Opinión</a>
-      </nav>
+      <div class="nav-menu" id="siteMenu">
+        <nav id="siteFilters" class="nav-links" aria-label="Categorías">
+          <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
+          <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
+          <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
+          <a class="chip" href="#" data-filter="startups">Startups</a>
+          <a class="chip" href="#" data-filter="opinion">Opinión</a>
+        </nav>
 
-      <div class="actions">
-        <div class="search">
-          <form id="searchForm" action="search.html">
-            <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
-              <i class="bi bi-search"></i>
-            </button>
-            <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" aria-controls="searchSuggestions" aria-expanded="false" />
-          </form>
-          <ul id="searchSuggestions" class="suggestions" role="listbox"></ul>
+        <div class="actions">
+          <div class="search">
+            <form id="searchForm" action="search.html">
+              <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
+                <i class="bi bi-search"></i>
+              </button>
+              <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" aria-controls="searchSuggestions" aria-expanded="false" />
+            </form>
+            <ul id="searchSuggestions" class="suggestions" role="listbox"></ul>
+          </div>
+          <!-- Theme switch -->
+          <label class="switch-name">
+            <input id="themeToggle" type="checkbox" class="checkbox" role="switch" name="theme" value="dark" aria-label="Cambiar a modo oscuro">
+            <div class="back"></div>
+            <svg class="moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+              <path d="M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z"></path>
+            </svg>
+            <svg class="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+              <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z"></path>
+            </svg>
+          </label>
         </div>
-        <!-- Theme switch -->
-        <label class="switch-name">
-          <input id="themeToggle" type="checkbox" class="checkbox" role="switch" name="theme" value="dark" aria-label="Cambiar a modo oscuro">
-          <div class="back"></div>
-          <svg class="moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-            <path d="M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z"></path>
-          </svg>
-          <svg class="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-            <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z"></path>
-          </svg>
-        </label>
       </div>
     </div>
   </header>

--- a/post.html
+++ b/post.html
@@ -28,40 +28,42 @@
         </span>
       </a>
 
-      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="siteFilters" aria-haspopup="true">
-        <i class="bi bi-funnel" aria-hidden="true"></i>
-        <span>Categorías</span>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="siteMenu" aria-haspopup="true">
+        <i class="bi bi-list" aria-hidden="true"></i>
+        <span>Menú y filtros</span>
       </button>
 
-      <nav id="siteFilters" class="nav-links" aria-label="Categorías">
-        <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
-        <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
-        <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
-        <a class="chip" href="#" data-filter="startups">Startups</a>
-        <a class="chip" href="#" data-filter="opinion">Opinión</a>
-      </nav>
+      <div class="nav-menu" id="siteMenu">
+        <nav id="siteFilters" class="nav-links" aria-label="Categorías">
+          <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
+          <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
+          <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
+          <a class="chip" href="#" data-filter="startups">Startups</a>
+          <a class="chip" href="#" data-filter="opinion">Opinión</a>
+        </nav>
 
-      <div class="actions">
-        <div class="search">
-          <form id="searchForm" action="search.html">
-            <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
-              <i class="bi bi-search"></i>
-            </button>
-            <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" aria-controls="searchSuggestions" aria-expanded="false" />
-          </form>
-          <ul id="searchSuggestions" class="suggestions" role="listbox"></ul>
+        <div class="actions">
+          <div class="search">
+            <form id="searchForm" action="search.html">
+              <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
+                <i class="bi bi-search"></i>
+              </button>
+              <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" aria-controls="searchSuggestions" aria-expanded="false" />
+            </form>
+            <ul id="searchSuggestions" class="suggestions" role="listbox"></ul>
+          </div>
+          <!-- Theme switch -->
+          <label class="switch-name">
+            <input id="themeToggle" type="checkbox" class="checkbox" role="switch" name="theme" value="dark" aria-label="Cambiar a modo oscuro">
+            <div class="back"></div>
+            <svg class="moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+              <path d="M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z"></path>
+            </svg>
+            <svg class="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+              <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z"></path>
+            </svg>
+          </label>
         </div>
-        <!-- Theme switch -->
-        <label class="switch-name">
-          <input id="themeToggle" type="checkbox" class="checkbox" role="switch" name="theme" value="dark" aria-label="Cambiar a modo oscuro">
-          <div class="back"></div>
-          <svg class="moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-            <path d="M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z"></path>
-          </svg>
-          <svg class="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-            <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z"></path>
-          </svg>
-        </label>
       </div>
     </div>
   </header>

--- a/search.html
+++ b/search.html
@@ -28,40 +28,42 @@
         </span>
       </a>
 
-      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="siteFilters" aria-haspopup="true">
-        <i class="bi bi-funnel" aria-hidden="true"></i>
-        <span>Categorías</span>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="siteMenu" aria-haspopup="true">
+        <i class="bi bi-list" aria-hidden="true"></i>
+        <span>Menú y filtros</span>
       </button>
 
-      <nav id="siteFilters" class="nav-links" aria-label="Categorías">
-        <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
-        <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
-        <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
-        <a class="chip" href="#" data-filter="startups">Startups</a>
-        <a class="chip" href="#" data-filter="opinion">Opinión</a>
-      </nav>
+      <div class="nav-menu" id="siteMenu">
+        <nav id="siteFilters" class="nav-links" aria-label="Categorías">
+          <a class="chip" href="#" data-filter="todas" aria-current="page">Todas</a>
+          <a class="chip" href="#" data-filter="tecnologia">Tecnología</a>
+          <a class="chip" href="#" data-filter="ciencia">Ciencia</a>
+          <a class="chip" href="#" data-filter="startups">Startups</a>
+          <a class="chip" href="#" data-filter="opinion">Opinión</a>
+        </nav>
 
-      <div class="actions">
-        <div class="search">
-          <form id="searchForm" action="search.html">
-            <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
-              <i class="bi bi-search"></i>
-            </button>
-            <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" aria-controls="searchSuggestions" aria-expanded="false" />
-          </form>
-          <ul id="searchSuggestions" class="suggestions" role="listbox"></ul>
+        <div class="actions">
+          <div class="search">
+            <form id="searchForm" action="search.html">
+              <button id="searchBtn" class="search-button" aria-label="Buscar" aria-expanded="false">
+                <i class="bi bi-search"></i>
+              </button>
+              <input id="q" class="search-input" type="search" placeholder="Buscar en el sitio…" autocomplete="off" hidden aria-label="Buscar en el sitio" aria-controls="searchSuggestions" aria-expanded="false" />
+            </form>
+            <ul id="searchSuggestions" class="suggestions" role="listbox"></ul>
+          </div>
+          <!-- Theme switch -->
+          <label class="switch-name">
+            <input id="themeToggle" type="checkbox" class="checkbox" role="switch" name="theme" value="dark" aria-label="Cambiar a modo oscuro">
+            <div class="back"></div>
+            <svg class="moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
+              <path d="M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z"></path>
+            </svg>
+            <svg class="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+              <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z"></path>
+            </svg>
+          </label>
         </div>
-        <!-- Theme switch -->
-        <label class="switch-name">
-          <input id="themeToggle" type="checkbox" class="checkbox" role="switch" name="theme" value="dark" aria-label="Cambiar a modo oscuro">
-          <div class="back"></div>
-          <svg class="moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-            <path d="M223.5 32C100 32 0 132.3 0 256S100 480 223.5 480c60.6 0 115.5-24.2 155.8-63.4c5-4.9 6.3-12.5 3.1-18.7s-10.1-9.7-17-8.5c-9.8 1.7-19.8 2.6-30.1 2.6c-96.9 0-175.5-78.8-175.5-176c0-65.8 36-123.1 89.3-153.3c6.1-3.5 9.2-10.5 7.7-17.3s-7.3-11.9-14.3-12.5c-6.3-.5-12.6-.8-19-.8z"></path>
-          </svg>
-          <svg class="sun" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-            <path d="M361.5 1.2c5 2.1 8.6 6.6 9.6 11.9L391 121l107.9 19.8c5.3 1 9.8 4.6 11.9 9.6s1.5 10.7-1.6 15.2L446.9 256l62.3 90.3c3.1 4.5 3.7 10.2 1.6 15.2s-6.6 8.6-11.9 9.6L391 391 371.1 498.9c-1 5.3-4.6 9.8-9.6 11.9s-10.7 1.5-15.2-1.6L256 446.9l-90.3 62.3c-4.5 3.1-10.2 3.7-15.2 1.6s-8.6-6.6-9.6-11.9L121 391 13.1 371.1c-5.3-1-9.8-4.6-11.9-9.6s-1.5-10.7 1.6-15.2L65.1 256 2.8 165.7c-3.1-4.5-3.7-10.2-1.6-15.2s6.6-8.6 11.9-9.6L121 121 140.9 13.1c1-5.3 4.6-9.8 9.6-11.9s10.7-1.5 15.2 1.6L256 65.1 346.3 2.8c4.5-3.1 10.2-3.7 15.2-1.6zM160 256a96 96 0 1 1 192 0 96 96 0 1 1 -192 0zm224 0a128 128 0 1 0 -256 0 128 128 0 1 0 256 0z"></path>
-          </svg>
-        </label>
       </div>
     </div>
   </header>

--- a/styles.css
+++ b/styles.css
@@ -102,6 +102,13 @@ header.site-header {
 }
 .brand small { display: block; color: var(--muted); font-weight: 600; font-size: 0.75em; margin-top: -0.375em; }
 
+.nav-menu {
+  display: flex;
+  align-items: center;
+  gap: 0.75em;
+  margin-left: auto;
+}
+
 .nav-links { display: flex; gap: 0.625em; flex-wrap: wrap; }
 .chip {
   display: inline-flex; align-items: center; gap: 0.5em; padding: 0.5em 0.75em; border: 0.0625em solid var(--border); border-radius: 62.4375em; background: var(--panel);
@@ -604,14 +611,14 @@ footer {
   .mini { grid-template-columns: 1fr; }
   .nav { flex-wrap: wrap; align-items: center; row-gap: 0.75em; }
   .nav-toggle { display: inline-flex; order: 2; }
-  .actions { order: 3; }
-  .nav-links[data-collapsible="true"] {
+  .nav-menu[data-collapsible="true"] {
     position: absolute;
     top: calc(100% + 0.75em);
     left: 1.25em;
     right: 1.25em;
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: 0.75em;
     padding: 0.75em;
     background: var(--panel);
@@ -625,16 +632,26 @@ footer {
     transition: opacity var(--transDur) ease, transform var(--transDur) ease, visibility 0s linear var(--transDur);
     z-index: 60;
   }
-  .nav-links[data-collapsible="true"].is-open {
+  .nav-menu[data-collapsible="true"].is-open {
     visibility: visible;
     opacity: 1;
     transform: translateY(0);
     pointer-events: auto;
     transition: opacity var(--transDur) ease, transform var(--transDur) ease;
   }
-  .nav-links[data-collapsible="true"] .chip {
+  .nav-menu[data-collapsible="true"] .nav-links {
+    flex-direction: column;
+    gap: 0.75em;
+  }
+  .nav-menu[data-collapsible="true"] .chip {
     width: 100%;
     justify-content: center;
+  }
+  .nav-menu[data-collapsible="true"] .actions {
+    margin-left: 0;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.75em;
   }
   footer {
     display: flex;

--- a/utils/nav.js
+++ b/utils/nav.js
@@ -1,14 +1,14 @@
 export function initNavDisclosure(breakpoint = '(max-width: 40em)') {
-  const nav = document.querySelector('.nav-links');
+  const menu = document.querySelector('.nav-menu');
   const toggle = document.querySelector('.nav-toggle');
-  if (!nav || !toggle) return null;
+  if (!menu || !toggle) return null;
 
   const mediaQuery = window.matchMedia(breakpoint);
   let previousFocus = null;
   let listenersAttached = false;
 
   const handleDocumentClick = (event) => {
-    if (!nav.contains(event.target) && !toggle.contains(event.target)) {
+    if (!menu.contains(event.target) && !toggle.contains(event.target)) {
       closeNav({ returnFocus: false });
     }
   };
@@ -40,12 +40,12 @@ export function initNavDisclosure(breakpoint = '(max-width: 40em)') {
 
     previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : toggle;
     toggle.setAttribute('aria-expanded', 'true');
-    nav.classList.add('is-open');
-    nav.removeAttribute('aria-hidden');
+    menu.classList.add('is-open');
+    menu.removeAttribute('aria-hidden');
     addGlobalListeners();
 
     if (focusFirst) {
-      const focusable = nav.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+      const focusable = menu.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
       if (focusable instanceof HTMLElement) {
         focusable.focus();
       }
@@ -55,9 +55,9 @@ export function initNavDisclosure(breakpoint = '(max-width: 40em)') {
   function closeNav({ returnFocus = true } = {}) {
     if (toggle.getAttribute('aria-expanded') === 'false') {
       if (mediaQuery.matches) {
-        nav.setAttribute('aria-hidden', 'true');
+        menu.setAttribute('aria-hidden', 'true');
       } else {
-        nav.removeAttribute('aria-hidden');
+        menu.removeAttribute('aria-hidden');
       }
       removeGlobalListeners();
       if (returnFocus && previousFocus && typeof previousFocus.focus === 'function') {
@@ -68,11 +68,11 @@ export function initNavDisclosure(breakpoint = '(max-width: 40em)') {
     }
 
     toggle.setAttribute('aria-expanded', 'false');
-    nav.classList.remove('is-open');
+    menu.classList.remove('is-open');
     if (mediaQuery.matches) {
-      nav.setAttribute('aria-hidden', 'true');
+      menu.setAttribute('aria-hidden', 'true');
     } else {
-      nav.removeAttribute('aria-hidden');
+      menu.removeAttribute('aria-hidden');
     }
     removeGlobalListeners();
 
@@ -84,24 +84,25 @@ export function initNavDisclosure(breakpoint = '(max-width: 40em)') {
 
   function syncState() {
     if (mediaQuery.matches) {
-      nav.setAttribute('data-collapsible', 'true');
+      menu.setAttribute('data-collapsible', 'true');
       toggle.hidden = false;
       if (toggle.getAttribute('aria-expanded') === 'true') {
-        nav.classList.add('is-open');
-        nav.removeAttribute('aria-hidden');
+        menu.classList.add('is-open');
+        menu.removeAttribute('aria-hidden');
         addGlobalListeners();
       } else {
-        nav.classList.remove('is-open');
-        nav.setAttribute('aria-hidden', 'true');
+        menu.classList.remove('is-open');
+        menu.setAttribute('aria-hidden', 'true');
         removeGlobalListeners();
       }
     } else {
-      nav.classList.remove('is-open');
-      nav.removeAttribute('data-collapsible');
-      nav.removeAttribute('aria-hidden');
+      menu.classList.remove('is-open');
+      menu.removeAttribute('data-collapsible');
+      menu.removeAttribute('aria-hidden');
       toggle.hidden = true;
       toggle.setAttribute('aria-expanded', 'false');
       removeGlobalListeners();
+      previousFocus = null;
     }
   }
 


### PR DESCRIPTION
## Summary
- wrap the navigation links and header actions in a shared nav-menu container on every page and update the toggle button icon/text
- adjust responsive styles so the new container slides open on small screens while keeping the action buttons inside
- update the disclosure script to manage the new container, syncing aria-hidden states and focus behaviour across breakpoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbd85943e8832b8625d50f20445663