### PR TITLE
Make embedded videos responsive in posts

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -394,6 +394,29 @@ header.site-header {
   border-radius: 0.5em;
 }
 
+#post iframe,
+#post-content iframe {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  border: 0;
+  margin: 0;
+}
+
+#post-content .wp-block-embed,
+#post-content .wp-block-embed__wrapper {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+}
+
+#post-content .wp-block-embed__wrapper {
+  aspect-ratio: 16 / 9;
+}
+
 #post-content .separator,
 #post-content figure {
   max-width: 100%;


### PR DESCRIPTION
## Summary
- add responsive styling so post iframes and Gutenberg embed wrappers fill the card width with a 16:9 aspect ratio
- reset Gutenberg embed containers inside #post-content to max-width: 100% without stray margins

## Testing
- manual: served the site with `npx http-server -p 4173` and opened `/post.html?id=19074` to confirm the YouTube embed spans the post width


------
https://chatgpt.com/codex/tasks/task_e_68cc0d679ff0832ba8ced01020c0b124