### PR TITLE
Replace emoticons with Material Symbols icons

### DIFF
--- a/contactanos.html
+++ b/contactanos.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Contáctanos</title>
   <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -44,9 +45,27 @@
         <div class="side-panel">
           <h3>Canales directos</h3>
           <ul>
-            <li><span>✉️ Correo editorial</span><span>editorial@anxina.com</span></li>
-            <li><span>🛰️ Pistas de última hora</span><span>tips@anxina.com</span></li>
-            <li><span>🎙️ Invitaciones</span><span>podcast@anxina.com</span></li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+                Correo editorial
+              </span>
+              <span>editorial@anxina.com</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">satellite_alt</span>
+                Pistas de última hora
+              </span>
+              <span>tips@anxina.com</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">mic</span>
+                Invitaciones
+              </span>
+              <span>podcast@anxina.com</span>
+            </li>
           </ul>
         </div>
         <div class="side-panel">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Terminal de noticias tecnológicas</title>
   <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -53,9 +54,24 @@
           <h2>Radar rápido</h2>
           <p>Actualizaciones curadas para decidir qué abrir primero.</p>
           <ul>
-            <li>📡 Chips abiertos: nuevos consorcios en Brasil y México.</li>
-            <li>🛰️ Observación de la Tierra: datos más accesibles para startups.</li>
-            <li>🎮 Cultura gamer: lanzamientos clave en noviembre.</li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">sensors</span>
+                Chips abiertos: nuevos consorcios en Brasil y México.
+              </span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">satellite_alt</span>
+                Observación de la Tierra: datos más accesibles para startups.
+              </span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">sports_esports</span>
+                Cultura gamer: lanzamientos clave en noviembre.
+              </span>
+            </li>
           </ul>
           <div class="post__actions">
             <a class="button secondary" href="#stream">Ver titulares</a>
@@ -136,10 +152,34 @@
         <div class="side-panel">
           <h4>Series activas</h4>
           <ul>
-            <li><span>⚙️ Laboratorio</span><span>5</span></li>
-            <li><span>🛰️ Espacio & datos</span><span>3</span></li>
-            <li><span>🎮 Radar gamer</span><span>8</span></li>
-            <li><span>🧠 IA aplicada</span><span>4</span></li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">settings</span>
+                Laboratorio
+              </span>
+              <span>5</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">satellite_alt</span>
+                Espacio & datos
+              </span>
+              <span>3</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">sports_esports</span>
+                Radar gamer
+              </span>
+              <span>8</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">psychology</span>
+                IA aplicada
+              </span>
+              <span>4</span>
+            </li>
           </ul>
         </div>
         <div class="side-panel">

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Política de privacidad</title>
   <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -44,9 +45,27 @@
         <div class="side-panel">
           <h3>Datos que recopilamos</h3>
           <ul>
-            <li><span>📬 Boletín</span><span>Correo y preferencias</span></li>
-            <li><span>📊 Métricas</span><span>Visitas agregadas</span></li>
-            <li><span>💬 Mensajes</span><span>Contenido que nos envías</span></li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+                Boletín
+              </span>
+              <span>Correo y preferencias</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">query_stats</span>
+                Métricas
+              </span>
+              <span>Visitas agregadas</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">chat</span>
+                Mensajes
+              </span>
+              <span>Contenido que nos envías</span>
+            </li>
           </ul>
         </div>
         <div class="side-panel">

--- a/style.css
+++ b/style.css
@@ -239,6 +239,18 @@ a:focus {
   background: linear-gradient(90deg, var(--accent), transparent);
 }
 
+.material-symbols-outlined {
+  font-size: 1.1em;
+  line-height: 1;
+  vertical-align: text-bottom;
+}
+
+.icon-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .side-panel {
   background: var(--panel);
   border: 1px solid var(--border);

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Términos de servicio</title>
   <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -44,9 +45,27 @@
         <div class="side-panel">
           <h3>Uso del contenido</h3>
           <ul>
-            <li><span>📝 Citas</span><span>Permite compartir con crédito</span></li>
-            <li><span>🔗 Enlaces</span><span>Siempre con fuente visible</span></li>
-            <li><span>🚫 Reventa</span><span>No autorizada</span></li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">sticky_note_2</span>
+                Citas
+              </span>
+              <span>Permite compartir con crédito</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">link</span>
+                Enlaces
+              </span>
+              <span>Siempre con fuente visible</span>
+            </li>
+            <li>
+              <span class="icon-text">
+                <span class="material-symbols-outlined" aria-hidden="true">block</span>
+                Reventa
+              </span>
+              <span>No autorizada</span>
+            </li>
           </ul>
         </div>
         <div class="side-panel">


### PR DESCRIPTION
### Motivation
- Replace inline emoji/emoticons with consistent icon font usage for improved visual consistency and accessibility.
- Load the Google Material Symbols font and use its outlined glyphs per the Material Symbols guide.
- Provide small shared utility styles to align and size icons consistently with text.

### Description
- Added the Material Symbols font link (`<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />`) to pages that display icons (`index.html`, `contactanos.html`, `politica_de_privacidad.html`, `terminos_de_servicio.html`).
- Replaced emoji list markers with markup using `span` elements with the `material-symbols-outlined` class and wrapped text in an `icon-text` helper for alignment.
- Introduced CSS helpers in `style.css`: `.material-symbols-outlined` for sizing/vertical alignment and `.icon-text` for inline layout and spacing.
- Updated several content lists across pages to use the new icon markup instead of Unicode emoji.

### Testing
- Searched HTML files for emoji ranges using `rg` to verify replacements, and the search returned no remaining emoji matches (success).
- Served the site with `python -m http.server 8000` and executed a Playwright script to load `index.html` and capture a screenshot, which completed and produced an artifact (success).
- No unit tests apply as these are static HTML/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d50c9274832b9d538f93ec898890)