### PR TITLE
Place ANXiNA title inside header badge and remove "Terminal" label

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,10 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <span class="brand__badge">Terminal</span>
-        <div>
+        <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">

--- a/style.css
+++ b/style.css
@@ -66,21 +66,25 @@ a:focus {
 .brand__badge {
   background: var(--accent);
   color: #2a1f05;
-  padding: 6px 12px;
+  padding: 8px 14px;
   border-radius: 4px;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .brand__title {
-  font-size: 1.6rem;
+  font-size: 1.1rem;
   margin: 0;
+  letter-spacing: 0.16em;
 }
 
 .brand__subtitle {
-  margin: 4px 0 0;
+  margin: 0;
   color: var(--muted);
   font-size: 0.95rem;
 }


### PR DESCRIPTION
### Motivation
- Simplify the header by removing the redundant `Terminal` label and consolidating the brand into the badge for clearer, tighter branding.
- Make the yellow badge large enough and centered so the `ANXiNA` title fits visually inside the square instead of next to it.

### Description
- Update `index.html` to replace `<span class="brand__badge">Terminal</span>` with a badge containing the site title: `<div class="brand__badge"><h1 class="brand__title">ANXiNA</h1></div>` and move the subtitle below it.
- Modify `style.css` to increase `.brand__badge` padding and center its content using `display: flex; align-items: center; justify-content: center;`.
- Adjust `.brand__title` to a smaller `font-size` and add `letter-spacing`, and reset `.brand__subtitle` `margin` to align with the new layout.

### Testing
- Started a local server with `python -m http.server` and ran a Playwright script to visit `index.html` and capture a screenshot, which completed successfully.
- No unit tests were required for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e185a2f8832b8bc99869e76a87e0)