### PR TITLE
Add light theme and theme toggle switch

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -29,6 +29,10 @@
           <span>buscar</span>
           <input type="search" placeholder="Explorar miembros" />
         </label>
+        <button class="theme-toggle" type="button" aria-pressed="false">
+          <span class="theme-toggle__text">Tema oscuro</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -80,5 +84,6 @@
       <p>Gracias por impulsar periodismo con contexto y humanidad.</p>
     </div>
   </footer>
+  <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/contactanos.html
+++ b/contactanos.html
@@ -30,6 +30,10 @@
           <span>buscar</span>
           <input type="search" placeholder="Tema, autor o serie" />
         </label>
+        <button class="theme-toggle" type="button" aria-pressed="false">
+          <span class="theme-toggle__text">Tema oscuro</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -90,5 +94,6 @@
       <p>¿Buscas apoyar el proyecto? Visita <a href="benefactores.html">Benefactores</a>.</p>
     </div>
   </footer>
+  <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
           <span>buscar</span>
           <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
+        <button class="theme-toggle" type="button" aria-pressed="false">
+          <span class="theme-toggle__text">Tema oscuro</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -204,5 +208,6 @@
       </p>
     </div>
   </footer>
+  <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -30,6 +30,10 @@
           <span>buscar</span>
           <input type="search" placeholder="Buscar en la política" />
         </label>
+        <button class="theme-toggle" type="button" aria-pressed="false">
+          <span class="theme-toggle__text">Tema oscuro</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -89,5 +93,6 @@
       <p>Revisamos esta política cada semestre para mantenerla vigente.</p>
     </div>
   </footer>
+  <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -8,7 +8,25 @@
   --accent-strong: #ffd75e;
   --border: #3a2e16;
   --shadow: rgba(0, 0, 0, 0.45);
+  --page-bg: radial-gradient(circle at top, #1a150b, #0c0a06 60%);
+  --post-bg: rgba(18, 15, 9, 0.9);
+  --callout-bg: rgba(242, 193, 76, 0.08);
   font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f7f3e8;
+  --panel: #ffffff;
+  --text: #2b2415;
+  --muted: #6c5f3a;
+  --accent: #d88b1f;
+  --accent-strong: #b96b0b;
+  --border: #e4d9bb;
+  --shadow: rgba(54, 40, 13, 0.12);
+  --page-bg: radial-gradient(circle at top, #fdfaf4, #efe7d5 65%);
+  --post-bg: #fdf9f0;
+  --callout-bg: rgba(216, 139, 31, 0.12);
 }
 
 * {
@@ -17,7 +35,7 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top, #1a150b, #0c0a06 60%);
+  background: var(--page-bg);
   color: var(--text);
   line-height: 1.6;
 }
@@ -134,6 +152,54 @@ a:focus {
   min-width: 200px;
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.theme-toggle__switch {
+  width: 42px;
+  height: 22px;
+  border-radius: 999px;
+  background: var(--border);
+  position: relative;
+  transition: background 0.2s ease;
+}
+
+.theme-toggle__switch::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  transition: transform 0.2s ease;
+}
+
+[data-theme="light"] .theme-toggle__switch {
+  background: var(--accent);
+}
+
+[data-theme="light"] .theme-toggle__switch::after {
+  transform: translateX(20px);
+  background: var(--panel);
+}
+
 .hero {
   padding: 36px 0;
 }
@@ -176,7 +242,7 @@ a:focus {
 
 .post {
   border: 1px solid var(--border);
-  background: rgba(18, 15, 9, 0.9);
+  background: var(--post-bg);
   border-radius: 12px;
   padding: 20px;
   display: grid;
@@ -300,7 +366,7 @@ a:focus {
 
 .callout {
   border: 1px solid var(--accent);
-  background: rgba(242, 193, 76, 0.08);
+  background: var(--callout-bg);
   padding: 16px;
   border-radius: 8px;
   color: var(--text);

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -30,6 +30,10 @@
           <span>buscar</span>
           <input type="search" placeholder="Buscar en términos" />
         </label>
+        <button class="theme-toggle" type="button" aria-pressed="false">
+          <span class="theme-toggle__text">Tema oscuro</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -89,5 +93,6 @@
       <p>Gracias por mantener esta terminal informativa clara y segura.</p>
     </div>
   </footer>
+  <script src="theme-toggle.js"></script>
 </body>
 </html>

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -1,0 +1,27 @@
+(() => {
+  const root = document.documentElement;
+  const toggle = document.querySelector('.theme-toggle');
+  if (!toggle) {
+    return;
+  }
+  const text = toggle.querySelector('.theme-toggle__text');
+
+  const applyTheme = (theme) => {
+    root.dataset.theme = theme;
+    toggle.setAttribute('aria-pressed', theme === 'light');
+    if (text) {
+      text.textContent = theme === 'light' ? 'Tema claro' : 'Tema oscuro';
+    }
+  };
+
+  const stored = localStorage.getItem('theme');
+  const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+  const initialTheme = stored || (prefersLight ? 'light' : 'dark');
+  applyTheme(initialTheme);
+
+  toggle.addEventListener('click', () => {
+    const next = root.dataset.theme === 'light' ? 'dark' : 'light';
+    localStorage.setItem('theme', next);
+    applyTheme(next);
+  });
+})();


### PR DESCRIPTION
### Motivation
- Provide a light theme option so users can switch between light and dark color schemes for better readability and preference support.
- Make key UI surfaces (page background, post cards, callouts) theme-aware to keep visual consistency across themes.

### Description
- Add new CSS tokens and a light theme rule under `[data-theme="light"]` in `style.css` and replace fixed backgrounds with `--page-bg`, `--post-bg`, and `--callout-bg`.
- Add a header theme control markup (`button.theme-toggle`) to `index.html`, `contactanos.html`, `benefactores.html`, `politica_de_privacidad.html`, and `terminos_de_servicio.html`.
- Add `theme-toggle.js` which applies the theme to `document.documentElement.dataset.theme`, respects `prefers-color-scheme`, and persists the selection in `localStorage`.
- Add toggle-specific styles (switch, focus state, transitions) to `style.css` so the control updates visually when `data-theme` changes.

### Testing
- Started a local test server with `python -m http.server` and verified the site served successfully.
- Attempted an automated Playwright screenshot to validate the light theme toggle, but the script timed out and did not complete.
- No unit or integration tests were added or executed for these static HTML/CSS/JS changes.
- Confirmed changes were staged and committed (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e2a72290832b8adf1f085e6b8fa1)