### PR TITLE
Use Material Symbols icons for theme toggle

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -29,8 +29,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Explorar miembros" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Cambiar tema">
+          <span class="theme-toggle__text material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/contactanos.html
+++ b/contactanos.html
@@ -30,8 +30,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Tema, autor o serie" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Cambiar tema">
+          <span class="theme-toggle__text material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Cambiar tema">
+          <span class="theme-toggle__text material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -30,8 +30,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Buscar en la política" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Cambiar tema">
+          <span class="theme-toggle__text material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/style.css
+++ b/style.css
@@ -165,6 +165,11 @@ a:focus {
   cursor: pointer;
 }
 
+.theme-toggle__text {
+  font-size: 20px;
+  line-height: 1;
+}
+
 .theme-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -30,8 +30,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Buscar en términos" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Cambiar tema">
+          <span class="theme-toggle__text material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -10,7 +10,7 @@
     root.dataset.theme = theme;
     toggle.setAttribute('aria-pressed', theme === 'light');
     if (text) {
-      text.textContent = theme === 'light' ? 'Tema claro' : 'Tema oscuro';
+      text.textContent = theme === 'light' ? 'light_mode' : 'dark_mode';
     }
   };
 


### PR DESCRIPTION
### Motivation
- Replace Spanish text labels with visual icons so the theme toggle uses sun/moon Material Symbols for clearer affordance.
- Improve accessibility by keeping an accessible label on the button while switching visual content to icons.

### Description
- Update `theme-toggle.js` to set the toggle content to the Material Symbols names `light_mode` and `dark_mode` based on the active theme.
- Replace the textual label in `index.html`, `benefactores.html`, `contactanos.html`, `politica_de_privacidad.html`, and `terminos_de_servicio.html` with a `span` using the `material-symbols-outlined` class and add `aria-label="Cambiar tema"` on the button.
- Add `.theme-toggle__text` CSS to `style.css` to size the icon consistently alongside the existing switch element.

### Testing
- Served the site with `python -m http.server` and captured a screenshot via a Playwright script, which ran successfully and produced `artifacts/theme-toggle-icons.png`.
- No unit tests were added or required for this static UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e4a17108832ba76d5ca8b3d0eb8a)