### PR TITLE
Replace theme toggle text with Material Symbols sun/moon icons

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -29,8 +29,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Explorar miembros" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/contactanos.html
+++ b/contactanos.html
@@ -30,8 +30,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Tema, autor o serie" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/index.html
+++ b/index.html
@@ -29,8 +29,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -30,8 +30,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Buscar en la política" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/style.css
+++ b/style.css
@@ -165,6 +165,11 @@ a:focus {
   cursor: pointer;
 }
 
+.theme-toggle__icon {
+  font-size: 20px;
+  line-height: 1;
+}
+
 .theme-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -30,8 +30,8 @@
           <span>buscar</span>
           <input type="search" placeholder="Buscar en términos" />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false">
-          <span class="theme-toggle__text">Tema oscuro</span>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/theme-toggle.js
+++ b/theme-toggle.js
@@ -4,13 +4,14 @@
   if (!toggle) {
     return;
   }
-  const text = toggle.querySelector('.theme-toggle__text');
+  const icon = toggle.querySelector('.theme-toggle__icon');
 
   const applyTheme = (theme) => {
     root.dataset.theme = theme;
     toggle.setAttribute('aria-pressed', theme === 'light');
-    if (text) {
-      text.textContent = theme === 'light' ? 'Tema claro' : 'Tema oscuro';
+    toggle.setAttribute('aria-label', theme === 'light' ? 'Activar tema oscuro' : 'Activar tema claro');
+    if (icon) {
+      icon.textContent = theme === 'light' ? 'light_mode' : 'dark_mode';
     }
   };
 


### PR DESCRIPTION
### Motivation
- Replace the verbose Spanish toggle labels with compact icons to simplify the header UI and match the rest of the site's iconography.  
- Use Google Material Symbols for consistent visual language across components.  
- Preserve accessibility by keeping and updating `aria-label` on the toggle button to announce the action.  

### Description
- Replaced the `span.theme-toggle__text` in `index.html`, `contactanos.html`, `benefactores.html`, `politica_de_privacidad.html`, and `terminos_de_servicio.html` with `span.theme-toggle__icon` using the `material-symbols-outlined` glyph.  
- Updated `theme-toggle.js` to toggle the icon text between `light_mode` and `dark_mode` and to update the button `aria-label` based on the current theme.  
- Added `.theme-toggle__icon` styling to `style.css` to size and align the icon.  
- Kept the existing theme switching logic and `data-theme` behavior intact.  

### Testing
- Started a local server with `python -m http.server` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a full-page screenshot, which completed successfully (artifact produced).  
- No automated unit tests or CI tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e679b09c832bae10f670e8c65882)