### PR TITLE
Align header badge layout across pages

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -11,11 +11,10 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <span class="brand__badge">Terminal</span>
-        <div>
+        <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
-          <p class="brand__subtitle">Comunidad que impulsa el periodismo tech.</p>
         </div>
+        <p class="brand__subtitle">Comunidad que impulsa el periodismo tech.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">

--- a/contactanos.html
+++ b/contactanos.html
@@ -12,11 +12,10 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <span class="brand__badge">Terminal</span>
-        <div>
+        <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
-          <p class="brand__subtitle">Conversemos sobre ciencia y tecnología.</p>
         </div>
+        <p class="brand__subtitle">Conversemos sobre ciencia y tecnología.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -12,11 +12,10 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <span class="brand__badge">Terminal</span>
-        <div>
+        <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
-          <p class="brand__subtitle">Transparencia antes que algoritmos.</p>
         </div>
+        <p class="brand__subtitle">Transparencia antes que algoritmos.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -12,11 +12,10 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <span class="brand__badge">Terminal</span>
-        <div>
+        <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
-          <p class="brand__subtitle">Reglas claras para una comunidad segura.</p>
         </div>
+        <p class="brand__subtitle">Reglas claras para una comunidad segura.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">


### PR DESCRIPTION
### Motivation
- The index page wraps the `ANXiNA` title inside the yellow badge but the secondary pages used a separate `Terminal` label, causing inconsistent header layout. 
- Make header markup consistent so the site brand appears the same across pages and matches the index appearance. 
- Simplify the header markup to rely on the existing `.brand__badge` and `.brand__title` styles.

### Description
- Updated header markup in `benefactores.html`, `contactanos.html`, `politica_de_privacidad.html` and `terminos_de_servicio.html` to move the `ANXiNA` `h1` inside the `.brand__badge` container. 
- Removed the standalone `Terminal` badge text and placed the subtitle as a sibling `p.brand__subtitle` to preserve the existing visual order. 
- Changes are purely static HTML adjustments to the brand block and do not alter CSS rules.

### Testing
- Started a local server with `python -m http.server` to serve the files for visual verification (server started successfully). 
- Attempted an automated visual check with a Playwright script to capture a header screenshot, but Playwright crashed with a browser launch/`TargetClosedError` and the screenshot step failed. 
- No unit or integration test suite was applicable for this static HTML change and no additional automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e813d538832b83ba0fd7769f60e8)