### PR TITLE
Handle cookie consent dismissal when storage is unavailable

### DIFF
--- a/cookie-consent.js
+++ b/cookie-consent.js
@@ -8,15 +8,25 @@
   const rejectButton = banner.querySelector('[data-consent="reject"]');
   const customizeButton = banner.querySelector('[data-consent="customize"]');
   const details = banner.querySelector('.cookie-banner__details');
+  const storageKey = 'cookieConsent';
 
-  const storedConsent = localStorage.getItem('cookieConsent');
+  let storedConsent = null;
+  try {
+    storedConsent = window.localStorage.getItem(storageKey);
+  } catch (error) {
+    storedConsent = null;
+  }
   if (storedConsent) {
     banner.remove();
     return;
   }
 
   const dismiss = (value) => {
-    localStorage.setItem('cookieConsent', value);
+    try {
+      window.localStorage.setItem(storageKey, value);
+    } catch (error) {
+      // Ignore storage errors and still dismiss the banner.
+    }
     banner.dataset.state = 'dismissed';
     window.setTimeout(() => {
       banner.remove();


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when `localStorage` is unavailable or blocked by the browser. 
- Ensure the cookie banner is dismissed when the user clicks `Aceptar todas` or `Rechazar` even if storage operations fail. 

### Description
- Introduced a `storageKey` constant and wrapped `localStorage.getItem` in a `try/catch` to avoid exceptions during read. 
- Wrapped `localStorage.setItem` in a `try/catch` so writes are best-effort and the banner still dismisses on failure. 
- Left existing event listeners that call `dismiss(...)` for `accept`, `reject`, and `customize` in place, and updated `cookie-consent.js` accordingly. 

### Testing
- No automated tests were run for this change.
- The change is a small runtime-robustness update and was applied and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952eb95814c832b9a286f71a82de7b8)