### PR TITLE
Remove 'Reject' option from cookie banner (notice-only behavior)

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -88,7 +88,6 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button" type="button" data-consent="reject">Rechazar</button>
         <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
           Configurar
         </button>

--- a/contactanos.html
+++ b/contactanos.html
@@ -98,7 +98,6 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button" type="button" data-consent="reject">Rechazar</button>
         <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
           Configurar
         </button>

--- a/cookie-consent.js
+++ b/cookie-consent.js
@@ -5,7 +5,6 @@
   }
 
   const acceptButton = banner.querySelector('[data-consent="accept"]');
-  const rejectButton = banner.querySelector('[data-consent="reject"]');
   const customizeButton = banner.querySelector('[data-consent="customize"]');
   const details = banner.querySelector('.cookie-banner__details');
 
@@ -25,10 +24,6 @@
 
   if (acceptButton) {
     acceptButton.addEventListener('click', () => dismiss('accepted'));
-  }
-
-  if (rejectButton) {
-    rejectButton.addEventListener('click', () => dismiss('rejected'));
   }
 
   if (customizeButton && details) {

--- a/index.html
+++ b/index.html
@@ -210,7 +210,6 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button" type="button" data-consent="reject">Rechazar</button>
         <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
           Configurar
         </button>

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -97,7 +97,6 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button" type="button" data-consent="reject">Rechazar</button>
         <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
           Configurar
         </button>

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -97,7 +97,6 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button" type="button" data-consent="reject">Rechazar</button>
         <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
           Configurar
         </button>


### PR DESCRIPTION
### Motivation
- Treat the cookie banner as a notice by removing the explicit `Rechazar` action so staying on the site is considered consent.
- Simplify the UI and avoid tracking a `'rejected'` state in storage for this flow.

### Description
- Removed the `Rechazar` button markup from cookie banners in `index.html`, `benefactores.html`, `contactanos.html`, `politica_de_privacidad.html`, and `terminos_de_servicio.html`.
- Dropped the unused `reject` query and event handler from `cookie-consent.js`, keeping `accept` and `customize` behaviors intact.
- The `accept` button still stores `cookieConsent` as `'accepted'` in `localStorage`, and the cookie details toggle remains unchanged.

### Testing
- Started a local server with `python -m http.server` and served the site successfully.
- Ran a Playwright script to load `index.html` and capture a screenshot of the cookie banner which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952eda014e4832b9812824d2573012a)