### PR TITLE
Make cookie banner dismissal resilient and remove 'Configurar' option

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -88,19 +88,8 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
-          Configurar
-        </button>
         <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
       </div>
-    </div>
-    <div class="cookie-banner__details" id="cookie-details" hidden>
-      <strong>Tipos de cookies</strong>
-      <ul>
-        <li>Esenciales: permiten la navegación básica y guardar tus ajustes de tema.</li>
-        <li>Analíticas: nos ayudan a entender qué contenidos son más útiles.</li>
-        <li>Marketing: personalizan recomendaciones (desactivadas por defecto).</li>
-      </ul>
     </div>
   </div>
 

--- a/contactanos.html
+++ b/contactanos.html
@@ -98,19 +98,8 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
-          Configurar
-        </button>
         <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
       </div>
-    </div>
-    <div class="cookie-banner__details" id="cookie-details" hidden>
-      <strong>Tipos de cookies</strong>
-      <ul>
-        <li>Esenciales: permiten la navegación básica y guardar tus ajustes de tema.</li>
-        <li>Analíticas: nos ayudan a entender qué contenidos son más útiles.</li>
-        <li>Marketing: personalizan recomendaciones (desactivadas por defecto).</li>
-      </ul>
     </div>
   </div>
 

--- a/cookie-consent.js
+++ b/cookie-consent.js
@@ -5,17 +5,24 @@
   }
 
   const acceptButton = banner.querySelector('[data-consent="accept"]');
-  const customizeButton = banner.querySelector('[data-consent="customize"]');
-  const details = banner.querySelector('.cookie-banner__details');
-
-  const storedConsent = localStorage.getItem('cookieConsent');
+  const storedConsent = (() => {
+    try {
+      return localStorage.getItem('cookieConsent');
+    } catch (error) {
+      return null;
+    }
+  })();
   if (storedConsent) {
     banner.remove();
     return;
   }
 
   const dismiss = (value) => {
-    localStorage.setItem('cookieConsent', value);
+    try {
+      localStorage.setItem('cookieConsent', value);
+    } catch (error) {
+      // Local storage can be unavailable in private browsing contexts.
+    }
     banner.dataset.state = 'dismissed';
     window.setTimeout(() => {
       banner.remove();
@@ -24,17 +31,5 @@
 
   if (acceptButton) {
     acceptButton.addEventListener('click', () => dismiss('accepted'));
-  }
-
-  if (customizeButton && details) {
-    customizeButton.addEventListener('click', () => {
-      const isHidden = details.hasAttribute('hidden');
-      if (isHidden) {
-        details.removeAttribute('hidden');
-      } else {
-        details.setAttribute('hidden', '');
-      }
-      customizeButton.setAttribute('aria-expanded', String(isHidden));
-    });
   }
 })();

--- a/index.html
+++ b/index.html
@@ -210,19 +210,8 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
-          Configurar
-        </button>
         <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
       </div>
-    </div>
-    <div class="cookie-banner__details" id="cookie-details" hidden>
-      <strong>Tipos de cookies</strong>
-      <ul>
-        <li>Esenciales: permiten la navegación básica y guardar tus ajustes de tema.</li>
-        <li>Analíticas: nos ayudan a entender qué contenidos son más útiles.</li>
-        <li>Marketing: personalizan recomendaciones (desactivadas por defecto).</li>
-      </ul>
     </div>
   </div>
 

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -97,19 +97,8 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
-          Configurar
-        </button>
         <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
       </div>
-    </div>
-    <div class="cookie-banner__details" id="cookie-details" hidden>
-      <strong>Tipos de cookies</strong>
-      <ul>
-        <li>Esenciales: permiten la navegación básica y guardar tus ajustes de tema.</li>
-        <li>Analíticas: nos ayudan a entender qué contenidos son más útiles.</li>
-        <li>Marketing: personalizan recomendaciones (desactivadas por defecto).</li>
-      </ul>
     </div>
   </div>
 

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -97,19 +97,8 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button secondary" type="button" data-consent="customize" aria-expanded="false" aria-controls="cookie-details">
-          Configurar
-        </button>
         <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
       </div>
-    </div>
-    <div class="cookie-banner__details" id="cookie-details" hidden>
-      <strong>Tipos de cookies</strong>
-      <ul>
-        <li>Esenciales: permiten la navegación básica y guardar tus ajustes de tema.</li>
-        <li>Analíticas: nos ayudan a entender qué contenidos son más útiles.</li>
-        <li>Marketing: personalizan recomendaciones (desactivadas por defecto).</li>
-      </ul>
     </div>
   </div>
 


### PR DESCRIPTION
### Motivation
- The cookie banner did not always disappear when the user pressed accept because `localStorage` access can fail in some environments. 
- The site does not require the cookie `Configurar` button or the details panel, so removing them simplifies the UI.

### Description
- Wrap `localStorage.getItem` and `localStorage.setItem` calls in `try/catch` inside `cookie-consent.js` to avoid errors when storage is unavailable. 
- Remove the customize button, details panel and related markup from all pages (`index.html`, `benefactores.html`, `contactanos.html`, `politica_de_privacidad.html`, `terminos_de_servicio.html`).
- Remove the customize button event handling and details toggling from `cookie-consent.js` so only the accept flow remains. 

### Testing
- Launched a static server with `python -m http.server` and ran a Playwright script to load `index.html` and capture a screenshot, which completed successfully and produced `artifacts/cookie-banner.png`.
- No automated tests failed during the verification run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952eea9e450832bb1da5333d135ea6f)