### PR TITLE
Make cookie banner informational — remove persisted consent

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -88,7 +88,7 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
+        <button class="cookie-banner__button primary" type="button" data-consent="acknowledge">Entendido</button>
       </div>
     </div>
   </div>

--- a/contactanos.html
+++ b/contactanos.html
@@ -98,7 +98,7 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
+        <button class="cookie-banner__button primary" type="button" data-consent="acknowledge">Entendido</button>
       </div>
     </div>
   </div>

--- a/cookie-consent.js
+++ b/cookie-consent.js
@@ -4,32 +4,16 @@
     return;
   }
 
-  const acceptButton = banner.querySelector('[data-consent="accept"]');
-  const storedConsent = (() => {
-    try {
-      return localStorage.getItem('cookieConsent');
-    } catch (error) {
-      return null;
-    }
-  })();
-  if (storedConsent) {
-    banner.remove();
-    return;
-  }
+  const acknowledgeButton = banner.querySelector('[data-consent="acknowledge"]');
 
-  const dismiss = (value) => {
-    try {
-      localStorage.setItem('cookieConsent', value);
-    } catch (error) {
-      // Local storage can be unavailable in private browsing contexts.
-    }
+  const dismiss = () => {
     banner.dataset.state = 'dismissed';
     window.setTimeout(() => {
       banner.remove();
     }, 300);
   };
 
-  if (acceptButton) {
-    acceptButton.addEventListener('click', () => dismiss('accepted'));
+  if (acknowledgeButton) {
+    acknowledgeButton.addEventListener('click', dismiss);
   }
 })();

--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
+        <button class="cookie-banner__button primary" type="button" data-consent="acknowledge">Entendido</button>
       </div>
     </div>
   </div>

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -97,7 +97,7 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
+        <button class="cookie-banner__button primary" type="button" data-consent="acknowledge">Entendido</button>
       </div>
     </div>
   </div>

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -97,7 +97,7 @@
         </p>
       </div>
       <div class="cookie-banner__actions">
-        <button class="cookie-banner__button primary" type="button" data-consent="accept">Aceptar todas</button>
+        <button class="cookie-banner__button primary" type="button" data-consent="acknowledge">Entendido</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- The cookie banner previously persisted user consent in `localStorage`, but the intent is to show an informational pop-up with an acknowledge button that does not store state. 
- The change keeps the banner as a transient notice so that remaining on the site is considered consent without persisting data.

### Description
- Remove use of `localStorage` and stored consent checks from `cookie-consent.js` and change the dismiss handler to simply remove the banner. 
- Replace the button `data-consent` attribute from `accept` to `acknowledge` and change the label from "Aceptar todas" to "Entendido" across `index.html`, `benefactores.html`, `contactanos.html`, `politica_de_privacidad.html`, and `terminos_de_servicio.html`.
- Update the event listener to attach to the new `data-consent="acknowledge"` button and call the nondestructive `dismiss` function.

### Testing
- Served the site with `python -m http.server` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot of the banner, which completed successfully and produced `artifacts/cookie-banner.png`.
- No unit or integration tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952f0b1def8832b96d69266938398b6)