### PR TITLE
Improve mobile layout styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -378,6 +378,36 @@ a:focus {
 }
 
 @media (max-width: 720px) {
+  .site-header {
+    padding: 20px 0 12px;
+  }
+
+  .brand {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .brand__badge {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .header-meta {
+    gap: 12px;
+  }
+
+  .nav {
+    width: 100%;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .nav a {
+    width: 100%;
+    padding: 6px 0;
+  }
+
   .header-meta {
     flex-direction: column;
     align-items: flex-start;
@@ -385,10 +415,79 @@ a:focus {
 
   .search {
     width: 100%;
+    flex-wrap: wrap;
   }
 
   .search input {
     min-width: 0;
     width: 100%;
+  }
+
+  .theme-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero {
+    padding: 24px 0;
+  }
+
+  .hero__card {
+    padding: 16px;
+  }
+
+  .post {
+    padding: 16px;
+  }
+
+  .post__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .post__actions .button {
+    text-align: center;
+  }
+
+  .section-title {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .section-title::after {
+    width: 100%;
+  }
+
+  .side-panel li {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+
+@media (max-width: 480px) {
+  .brand__title {
+    font-size: 1rem;
+  }
+
+  .brand__subtitle {
+    font-size: 0.9rem;
+  }
+
+  .badge {
+    font-size: 0.75rem;
+  }
+
+  .hero__grid {
+    gap: 16px;
+  }
+
+  .post__meta {
+    gap: 8px;
+  }
+
+  .footer {
+    padding: 20px 0 32px;
   }
 }


### PR DESCRIPTION
### Motivation

- Improve the site's appearance and usability on small screens by reorganizing header, nav, and content blocks.  
- Ensure navigation, search, and theme controls stack and remain accessible on narrow viewports.  
- Reduce spacing and compress card/post layouts so content fits better on phones.  

### Description

- Updated `style.css` to add responsive rules under `@media (max-width: 720px)` to stack `.brand`, `.nav`, `.header-meta`, make `.search` and `.theme-toggle` full width, and adjust paddings.  
- Converted navigation to a vertical layout on small screens and made `.nav a` expand to full width for easier tapping.  
- Adjusted card and post spacing by changing `.hero__card`, `.post`, and `.post__actions` to use smaller padding and column-stacked actions.  
- Added an extra small-screen media query at `@media (max-width: 480px)` to tweak typography, badge sizing, grid gaps, and footer padding.  

### Testing

- Launched a local server with `python -m http.server` and captured a mobile viewport screenshot using a Playwright script, which completed successfully and produced `artifacts/mobile-index.png`.  
- Visual verification via the generated screenshot confirmed the stacked header/nav and tightened spacing on a 390×844 viewport.  
- No unit or integration tests were applicable since the change is static CSS only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953205a604c832bae95de442dc97bd7)