### PR TITLE
Prevent header elements from stretching on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -389,7 +389,7 @@ a:focus {
   }
 
   .brand__badge {
-    width: 100%;
+    width: fit-content;
     justify-content: flex-start;
   }
 
@@ -424,8 +424,9 @@ a:focus {
   }
 
   .theme-toggle {
-    width: 100%;
+    width: fit-content;
     justify-content: space-between;
+    align-self: flex-start;
   }
 
   .hero {


### PR DESCRIPTION
### Motivation
- Fix header controls that visually stretched full-width on narrow viewports and looked unbalanced.
- Make the brand badge and theme toggle size to their content to improve header alignment on mobile.

### Description
- Updated `style.css` inside `@media (max-width: 720px)` to change `.brand__badge` from `width: 100%` to `width: fit-content`.
- Updated `.theme-toggle` from `width: 100%` to `width: fit-content` and added `align-self: flex-start` to keep the toggle aligned with other header content.
- Change is CSS-only and scoped to the mobile media query so desktop layout is unchanged.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the site, which succeeded.
- Captured a visual verification screenshot using a Playwright script against `http://127.0.0.1:8000/index.html`, which produced an artifact image successfully.
- No unit or integration tests were applicable for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695324b42de8832b8ee58ca0f6e6ed59)