### PR TITLE
Replace search label text with Material Symbols search icon

### DIFF
--- a/benefactores.html
+++ b/benefactores.html
@@ -25,7 +25,7 @@
           <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span>buscar</span>
+          <span class="material-symbols-outlined" aria-hidden="true">search</span>
           <input type="search" placeholder="Explorar miembros" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">

--- a/contactanos.html
+++ b/contactanos.html
@@ -26,7 +26,7 @@
           <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span>buscar</span>
+          <span class="material-symbols-outlined" aria-hidden="true">search</span>
           <input type="search" placeholder="Tema, autor o serie" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
           <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span>buscar</span>
+          <span class="material-symbols-outlined" aria-hidden="true">search</span>
           <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">

--- a/politica_de_privacidad.html
+++ b/politica_de_privacidad.html
@@ -26,7 +26,7 @@
           <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span>buscar</span>
+          <span class="material-symbols-outlined" aria-hidden="true">search</span>
           <input type="search" placeholder="Buscar en la política" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">

--- a/terminos_de_servicio.html
+++ b/terminos_de_servicio.html
@@ -26,7 +26,7 @@
           <a class="active" href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span>buscar</span>
+          <span class="material-symbols-outlined" aria-hidden="true">search</span>
           <input type="search" placeholder="Buscar en términos" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">


### PR DESCRIPTION
### Motivation

- Improve the header search affordance by replacing the visible text label with a compact icon.
- Use the Google Material Symbols glyph to match the existing iconography in the site header.

### Description

- Replaced the `<span>buscar</span>` label with `<span class="material-symbols-outlined" aria-hidden="true">search</span>` inside the search `label` in `index.html`, `benefactores.html`, `contactanos.html`, `politica_de_privacidad.html`, and `terminos_de_servicio.html`.
- Kept the existing search `input` and `aria-label` on the `label` to preserve accessibility.
- Left the existing Material Symbols stylesheet link in pages that already included it so icons render consistently.
- Captured an updated UI screenshot to verify the visual change.

### Testing

- Served the site with `python -m http.server 8000` and loaded `index.html` to verify the icon rendered, which succeeded.
- Captured a full-page screenshot via Playwright to confirm the updated header appearance, which succeeded.
- No unit or integration test suite was run for this static HTML change.
- Visual check performed on the generated screenshot to validate the icon replacement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69532692966c832bbc4c26bb025fab7a)