### PR TITLE
Add ‘La redefinición de lo “suficiente”’ post and update homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,42 +42,14 @@
       <div class="container hero__grid">
         <article class="hero__card">
           <div class="badge">En portada</div>
-          <h2>Latinoamérica acelera la adopción de IA generativa</h2>
+          <h2>La redefinición de lo “suficiente”</h2>
           <p>
-            Un vistazo rápido a los casos reales que ya están cambiando salud, banca y educación. Analizamos las
-            herramientas, los retos y lo que falta para escalar de forma responsable.
+            Menos RAM para ti. Más memoria para la IA. Un análisis sobre cómo el discurso cambia cuando los costos
+            se disparan y la memoria se vuelve un recurso cada vez más disputado.
           </p>
           <div class="post__actions">
-            <a class="button" href="#stream">Leer análisis</a>
+            <a class="button" href="menos-ram-mas-discurso.html">Leer artículo</a>
             <a class="button secondary" href="politica_de_privacidad.html">Cómo trabajamos</a>
-          </div>
-        </article>
-        <article class="hero__card">
-          <div class="badge">Monitor diario</div>
-          <h2>Radar rápido</h2>
-          <p>Actualizaciones curadas para decidir qué abrir primero.</p>
-          <ul>
-            <li>
-              <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">sensors</span>
-                Chips abiertos: nuevos consorcios en Brasil y México.
-              </span>
-            </li>
-            <li>
-              <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">satellite_alt</span>
-                Observación de la Tierra: datos más accesibles para startups.
-              </span>
-            </li>
-            <li>
-              <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">sports_esports</span>
-                Cultura gamer: lanzamientos clave en noviembre.
-              </span>
-            </li>
-          </ul>
-          <div class="post__actions">
-            <a class="button secondary" href="#stream">Ver titulares</a>
           </div>
         </article>
       </div>
@@ -87,115 +59,19 @@
       <h3 class="section-title">Stream de noticias</h3>
       <div id="stream" class="stream">
         <article class="post">
-          <h4>La carrera por la conectividad rural entra en fase crítica</h4>
+          <h4>La redefinición de lo “suficiente”</h4>
           <div class="post__meta">
-            <span>2024-11-15</span>
-            <span>Editorial · Conectividad</span>
+            <span>2025-12-29</span>
+            <span>Tepokato · IA</span>
           </div>
-          <p>
-            Las alianzas público-privadas están cambiando la cobertura en zonas remotas. Revisamos indicadores, costos
-            y qué modelos podrían sostener el servicio en el tiempo.
-          </p>
+          <p>Menos RAM para ti. Más memoria para la IA.</p>
           <div class="post__tags">
-            <span>#infraestructura</span>
-            <span>#latam</span>
-            <span>#telecom</span>
+            <span>#ia</span>
           </div>
           <div class="post__actions">
-            <a class="button" href="#">Leer reporte</a>
-            <a class="button secondary" href="#">Guardar</a>
+            <a class="button" href="menos-ram-mas-discurso.html">Leer artículo</a>
           </div>
         </article>
-
-        <article class="post">
-          <h4>La nueva ola de ciberseguridad en fintech</h4>
-          <div class="post__meta">
-            <span>2024-11-12</span>
-            <span>Análisis · Seguridad</span>
-          </div>
-          <p>
-            Claves para entender por qué los ataques aumentan y cómo los equipos de defensa están priorizando
-            automatización, monitoreo 24/7 y educación de usuarios.
-          </p>
-          <div class="post__tags">
-            <span>#ciberseguridad</span>
-            <span>#fintech</span>
-          </div>
-          <div class="post__actions">
-            <a class="button" href="#">Leer análisis</a>
-            <a class="button secondary" href="#">Escuchar audio</a>
-          </div>
-        </article>
-
-        <article class="post">
-          <h4>Guía express: cómo elegir un celular para crear contenido</h4>
-          <div class="post__meta">
-            <span>2024-11-08</span>
-            <span>Guía · Hardware</span>
-          </div>
-          <p>
-            Desglosamos cámara, batería y herramientas de edición en una lista rápida para quienes graban, editan y
-            publican desde el móvil sin complicarse.
-          </p>
-          <div class="post__tags">
-            <span>#moviles</span>
-            <span>#creadores</span>
-          </div>
-          <div class="post__actions">
-            <a class="button" href="#">Leer guía</a>
-            <a class="button secondary" href="#">Descargar checklist</a>
-          </div>
-        </article>
-      </div>
-    </section>
-
-    <section class="container">
-      <h3 class="section-title">Panel de navegación rápida</h3>
-      <div class="hero__grid">
-        <div class="side-panel">
-          <h4>Series activas</h4>
-          <ul>
-            <li>
-              <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">settings</span>
-                Laboratorio
-              </span>
-              <span>5</span>
-            </li>
-            <li>
-              <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">satellite_alt</span>
-                Espacio & datos
-              </span>
-              <span>3</span>
-            </li>
-            <li>
-              <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">sports_esports</span>
-                Radar gamer
-              </span>
-              <span>8</span>
-            </li>
-            <li>
-              <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">psychology</span>
-                IA aplicada
-              </span>
-              <span>4</span>
-            </li>
-          </ul>
-        </div>
-        <div class="side-panel">
-          <h4>Boletín terminal</h4>
-          <p>Recibe un resumen semanal en 5 minutos, sin ruido y con contexto.</p>
-          <div class="post__actions">
-            <a class="button" href="contactanos.html">Suscribirme</a>
-            <a class="button secondary" href="benefactores.html">Apoyar</a>
-          </div>
-          <div class="callout" style="margin-top: 16px;">
-            Última edición: Tendencias de IA en la región y el futuro de los modelos abiertos.
-          </div>
-        </div>
       </div>
     </section>
   </main>

--- a/menos-ram-mas-discurso.html
+++ b/menos-ram-mas-discurso.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · La redefinición de lo “suficiente”</title>
+  <link rel="stylesheet" href="style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Opinión y análisis con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="index.html">Inicio</a>
+          <a href="benefactores.html">Benefactores</a>
+          <a href="contactanos.html">Contáctanos</a>
+          <a href="politica_de_privacidad.html">Privacidad</a>
+          <a href="terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="material-symbols-outlined" aria-hidden="true">search</span>
+          <input type="search" placeholder="Buscar en ANXiNA" />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · IA</div>
+        <h1>La redefinición de lo “suficiente”</h1>
+        <div class="post__meta">
+          <span>2025-12-29 · 21:28</span>
+          <span>Tepokato</span>
+        </div>
+        <img src="ram-ia.png" alt="Ilustración de módulos de RAM junto a un chip con temática de inteligencia artificial" style="width: 100%; border-radius: 12px;" />
+        <p>
+          En los últimos meses ha empezado a circular una idea curiosamente insistente: “8 GB o 4 Gb de RAM son más
+          que suficientes para la mayoría de los usuarios”. La escuchamos en presentaciones, la leemos en reseñas
+          patrocinadas y la vemos repetida como mantra en comunicados oficiales.
+        </p>
+        <p>
+          Lo curioso no es el argumento. Lo curioso es el momento.
+          Mientras la inteligencia artificial se expande a un ritmo voraz —modelos más grandes, sistemas residentes
+          en memoria, procesos que nunca duermen—, la RAM se ha convertido en uno de los recursos más presionados del
+          mercado tecnológico. No solo para centros de datos: también para la cadena de suministro completa.
+        </p>
+        <p>La IA no solo consume energía. Consume memoria. Mucha.</p>
+        <p>Y cuando algo se vuelve más caro de producir, alguien tiene que pagar la cuenta.</p>
+
+        <h2>La presión silenciosa sobre la RAM</h2>
+        <p>
+          Fabricar RAM hoy no es tan simple como hace cinco o diez años. La demanda masiva de servidores de IA, GPUs
+          especializadas y sistemas de entrenamiento ha desplazado prioridades. Los grandes compradores ya no son los
+          consumidores finales: son las corporaciones que entrenan modelos, los proveedores de nube y las empresas
+          que compiten por no quedarse atrás en la carrera de la automatización.
+        </p>
+        <p>¿El resultado?</p>
+        <p>
+          La RAM de alta capacidad se vuelve más costosa, más disputada y menos conveniente de incluir en productos
+          de consumo.
+        </p>
+        <p>Y aquí entra el giro narrativo.</p>
+
+        <h2>Redefinir lo “suficiente”</h2>
+        <p>Cuando incluir más RAM afecta directamente el margen de ganancia, el discurso cambia.</p>
+        <p>Ya no se habla de preparar equipos para el futuro, sino de optimización.</p>
+        <p>Ya no se enfatiza la multitarea real, sino casos de uso promedio.</p>
+        <p>Ya no se reconoce el crecimiento natural del software, sino que se nos pide ajustar expectativas.</p>
+        <p>Así, 8 GB no regresan porque sean ideales, sino porque son rentables.</p>
+        <p>El mensaje se envuelve en tecnicismos:</p>
+        <ul>
+          <li>“El sistema gestiona mejor la memoria”.</li>
+          <li>“La IA optimiza el uso de recursos”.</li>
+          <li>“La mayoría de usuarios no necesita más”.</li>
+        </ul>
+        <p>Todo suena razonable… hasta que el equipo empieza a sentirse viejo antes de tiempo.</p>
+
+        <h2>Obsolescencia por narrativa, no por hardware</h2>
+        <p>El problema no es que un dispositivo con 8 GB no funcione hoy.</p>
+        <p>
+          El problema es que se vende como suficiente para mañana, sabiendo que el software —especialmente el
+          impulsado por IA— no va a detener su crecimiento.
+        </p>
+        <p>Es una obsolescencia más sutil.</p>
+        <p>No te dicen que compres otro equipo.</p>
+        <p>Solo hacen que el tuyo se sienta limitado, lento, justo… demasiado pronto.</p>
+        <p>Y cuando llega ese punto, la culpa parece ser del usuario, no del diseño.</p>
+
+        <h2>Una pregunta incómoda</h2>
+        <p>Si la IA promete eficiencia, ¿por qué cada vez exige más recursos?</p>
+        <p>Si el hardware “ya es suficiente”, ¿por qué los sistemas siguen empujando límites invisibles?</p>
+        <p>Y si la memoria es tan crucial para el futuro digital, ¿por qué se nos pide conformarnos con menos?</p>
+        <p>Tal vez la respuesta no esté en la tecnología…</p>
+        <p>sino en los costos que nadie quiere asumir.</p>
+
+        <div class="post__tags">
+          <span>#ia</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="theme-toggle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Publish the provided article content from `menos-ram-mas-discurso.txt` as a full post on the site. 
- Feature the new article on the homepage to replace placeholder hero and stream entries. 
- Remove placeholder/newsletter filler so the site highlights the new analysis. 

### Description
- Add a new post page `menos-ram-mas-discurso.html` containing the article content, metadata, tags, and a featured image reference to `ram-ia.png`. 
- Update `index.html` hero card to link to the new article and replace the previous hero content with the new title and excerpt. 
- Replace the homepage stream entries with a single post preview for the new article and remove other placeholder posts. 

### Testing
- Served the site locally with `python -m http.server` to perform a visual smoke check, which started successfully. 
- Attempted automated visual checks with Playwright to capture screenshots, but the Playwright browser failed to launch and the screenshot step failed. 
- No unit or integration tests were run for these static content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953502783fc832ba87dd7c3acab589f)