### PR TITLE
Add Central clock to site header

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -75,6 +75,31 @@ a:focus {
   border-bottom: 1px solid var(--border);
 }
 
+.header-top {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.central-clock {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.central-clock__label {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.central-clock__time {
+  font-variant-numeric: tabular-nums;
+}
+
 .brand {
   display: flex;
   align-items: center;

--- a/assets/js/central-time.js
+++ b/assets/js/central-time.js
@@ -1,0 +1,37 @@
+const centralTimeNodes = document.querySelectorAll("[data-central-time]");
+
+if (centralTimeNodes.length) {
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Chicago",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  const updateCentralTime = () => {
+    const now = new Date();
+    const parts = formatter.formatToParts(now);
+    const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+    const formatted = `${lookup.year}/${lookup.month}/${lookup.day} ${lookup.hour}:${lookup.minute}`;
+
+    centralTimeNodes.forEach((node) => {
+      node.textContent = formatted;
+    });
+  };
+
+  const scheduleTick = () => {
+    const now = new Date();
+    const msUntilNextMinute =
+      (60 - now.getSeconds()) * 1000 - now.getMilliseconds();
+    window.setTimeout(() => {
+      updateCentralTime();
+      scheduleTick();
+    }, msUntilNextMinute);
+  };
+
+  updateCentralTime();
+  scheduleTick();
+}

--- a/index.html
+++ b/index.html
@@ -11,6 +11,12 @@
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+      </div>
       <div class="brand">
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
@@ -84,6 +90,7 @@
       </p>
     </div>
   </footer>
+  <script src="assets/js/central-time.js"></script>
   <script src="assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -10,6 +10,12 @@
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+      </div>
       <div class="brand">
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
@@ -83,6 +89,7 @@
       <p>Gracias por impulsar periodismo con contexto y humanidad.</p>
     </div>
   </footer>
+  <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -11,6 +11,12 @@
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+      </div>
       <div class="brand">
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
@@ -93,6 +99,7 @@
       <p>¿Buscas apoyar el proyecto? Visita <a href="benefactores.html">Benefactores</a>.</p>
     </div>
   </footer>
+  <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -11,6 +11,12 @@
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+      </div>
       <div class="brand">
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
@@ -92,6 +98,7 @@
       <p>Revisamos esta política cada semestre para mantenerla vigente.</p>
     </div>
   </footer>
+  <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -11,6 +11,12 @@
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+      </div>
       <div class="brand">
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
@@ -92,6 +98,7 @@
       <p>Gracias por mantener esta terminal informativa clara y segura.</p>
     </div>
   </footer>
+  <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -11,6 +11,12 @@
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+      </div>
       <div class="brand">
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
@@ -119,6 +125,7 @@
       </p>
     </div>
   </footer>
+  <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Display the Central (America/Chicago) date/time in the header to provide a single reference across the site.  
- Make the timezone label explicit using the legend `Central` for clarity.  
- Use a compact, machine-friendly timestamp format `YYYY/MM/DD HH:MM` for easy reading.  
- Ensure the clock can be updated automatically and announced to assistive technologies via `aria-live`.

### Description
- Added CSS rules in `assets/css/style.css` for a new `.header-top` container and `.central-clock` components including `.central-clock__label` and `.central-clock__time` styling.  
- Implemented `assets/js/central-time.js` which uses `Intl.DateTimeFormat` with `timeZone: "America/Chicago"` to render `YYYY/MM/DD HH:MM` and schedules minute-aligned updates.  
- Injected the central clock markup into `index.html`, `posts/menos-ram-mas-discurso.html`, and site pages under `pages/` and appended the `central-time.js` script include in each page.  
- Kept the implementation accessible by adding `aria-live="polite"` to the clock container and using tabular numeric styling for consistent rendering.

### Testing
- Launched a local server with `python -m http.server 8000` and ran a Playwright script to load `http://127.0.0.1:8000/index.html` which produced a screenshot `artifacts/central-time.png` confirming the clock renders.  
- The Playwright run completed successfully and a visual artifact was captured for verification.  
- No unit tests were added or required for this static/visual enhancement.  
- All modified files were committed after verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69535eb2b8d0832bba8623423d1e2cb7)