### PR TITLE
Standardize shared header/footer content across pages

### DIFF
--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Benefactores</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -20,7 +21,7 @@
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
         </div>
-        <p class="brand__subtitle">Comunidad que impulsa el periodismo tech.</p>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
@@ -32,7 +33,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Explorar miembros" />
+          <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
@@ -86,7 +87,10 @@
 
   <footer class="footer">
     <div class="container">
-      <p>Gracias por impulsar periodismo con contexto y humanidad.</p>
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a>.
+      </p>
     </div>
   </footer>
   <script src="../assets/js/central-time.js"></script>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -21,7 +21,7 @@
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
         </div>
-        <p class="brand__subtitle">Conversemos sobre ciencia y tecnología.</p>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
@@ -33,7 +33,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Tema, autor o serie" />
+          <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
@@ -96,7 +96,10 @@
 
   <footer class="footer">
     <div class="container">
-      <p>¿Buscas apoyar el proyecto? Visita <a href="benefactores.html">Benefactores</a>.</p>
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a>.
+      </p>
     </div>
   </footer>
   <script src="../assets/js/central-time.js"></script>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -21,7 +21,7 @@
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
         </div>
-        <p class="brand__subtitle">Transparencia antes que algoritmos.</p>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
@@ -33,7 +33,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Buscar en la política" />
+          <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
@@ -95,7 +95,10 @@
 
   <footer class="footer">
     <div class="container">
-      <p>Revisamos esta política cada semestre para mantenerla vigente.</p>
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a>.
+      </p>
     </div>
   </footer>
   <script src="../assets/js/central-time.js"></script>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -21,7 +21,7 @@
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
         </div>
-        <p class="brand__subtitle">Reglas claras para una comunidad segura.</p>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
@@ -33,7 +33,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Buscar en términos" />
+          <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
@@ -95,7 +95,10 @@
 
   <footer class="footer">
     <div class="container">
-      <p>Gracias por mantener esta terminal informativa clara y segura.</p>
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a>.
+      </p>
     </div>
   </footer>
   <script src="../assets/js/central-time.js"></script>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -21,7 +21,7 @@
         <div class="brand__badge">
           <h1 class="brand__title">ANXiNA</h1>
         </div>
-        <p class="brand__subtitle">Opinión y análisis con señal clara.</p>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
@@ -33,7 +33,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Buscar en ANXiNA" />
+          <input type="search" placeholder="Escribe un tema o palabra clave" />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>


### PR DESCRIPTION
### Motivation
- Make shared UI elements consistent across the site by unifying header subtitles, search placeholders and footer copy. 
- Ensure iconography renders consistently by loading the Material Symbols font where missing. 
- Reduce small content differences that created an inconsistent experience between the homepage, post and static pages. 

### Description
- Updated the brand subtitle to `Noticias de tecnología, ciencia y videojuegos con señal clara.` across `pages/benefactores.html`, `pages/contactanos.html`, `pages/politica_de_privacidad.html`, `pages/terminos_de_servicio.html` and `posts/menos-ram-mas-discurso.html`. 
- Standardized the search input placeholder to `Escribe un tema o palabra clave` in the same files. 
- Replaced various footer lines with the unified ANXiNA footer containing links to `contactanos.html` and `politica_de_privacidad.html` in the static pages. 
- Added the Material Symbols stylesheet link to pages that were missing it so icons (e.g. `material-symbols-outlined`) render consistently. 

### Testing
- Started a local static server with `python -m http.server 8000` and it served files successfully. 
- Attempted an automated visual check using Playwright to capture a screenshot, but the browser process crashed and the screenshot step failed. 
- No other automated unit or integration tests were run for these static content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695362b7b668832bb2c0ec993ca68b75)