### PR TITLE
Consolidate page navigation into terminal-style menu

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -158,6 +158,78 @@ a:focus {
   border-color: var(--accent);
 }
 
+.nav-menu {
+  position: relative;
+}
+
+.nav-menu > summary {
+  list-style: none;
+}
+
+.nav-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.nav-menu__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px dashed var(--border);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.nav-menu__prompt {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.nav-menu[open] .nav-menu__toggle {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.nav-menu__panel {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  min-width: 240px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  box-shadow: 0 12px 24px var(--shadow);
+  display: grid;
+  gap: 8px;
+  z-index: 10;
+}
+
+.nav-menu__panel a {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+}
+
+.nav-menu__panel a.active,
+.nav-menu__panel a:hover {
+  border-color: var(--accent);
+}
+
+.nav-menu__command {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+
 .search {
   display: flex;
   align-items: center;
@@ -431,6 +503,21 @@ a:focus {
   .nav a {
     width: 100%;
     padding: 6px 0;
+  }
+
+  .nav-menu {
+    width: 100%;
+  }
+
+  .nav-menu__toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .nav-menu__panel {
+    position: static;
+    width: 100%;
+    margin-top: 8px;
   }
 
   .header-meta {

--- a/index.html
+++ b/index.html
@@ -26,10 +26,19 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a class="active" href="index.html">Inicio</a>
-          <a href="pages/benefactores.html">Benefactores</a>
-          <a href="pages/contactanos.html">Contáctanos</a>
-          <a href="pages/politica_de_privacidad.html">Privacidad</a>
-          <a href="pages/terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary class="nav-menu__toggle">
+              <span class="nav-menu__prompt" aria-hidden="true">&gt;</span>
+              Menú de páginas
+              <span class="material-symbols-outlined" aria-hidden="true">expand_more</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a role="menuitem" href="pages/benefactores.html"><span class="nav-menu__command">cat</span> Benefactores</a>
+              <a role="menuitem" href="pages/contactanos.html"><span class="nav-menu__command">ping</span> Contáctanos</a>
+              <a role="menuitem" href="pages/politica_de_privacidad.html"><span class="nav-menu__command">less</span> Privacidad</a>
+              <a role="menuitem" href="pages/terminos_de_servicio.html"><span class="nav-menu__command">man</span> Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -26,10 +26,19 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a class="active" href="benefactores.html">Benefactores</a>
-          <a href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Privacidad</a>
-          <a href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary class="nav-menu__toggle">
+              <span class="nav-menu__prompt" aria-hidden="true">&gt;</span>
+              Menú de páginas
+              <span class="material-symbols-outlined" aria-hidden="true">expand_more</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a class="active" role="menuitem" href="benefactores.html"><span class="nav-menu__command">cat</span> Benefactores</a>
+              <a role="menuitem" href="contactanos.html"><span class="nav-menu__command">ping</span> Contáctanos</a>
+              <a role="menuitem" href="politica_de_privacidad.html"><span class="nav-menu__command">less</span> Privacidad</a>
+              <a role="menuitem" href="terminos_de_servicio.html"><span class="nav-menu__command">man</span> Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -26,10 +26,19 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a class="active" href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Privacidad</a>
-          <a href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary class="nav-menu__toggle">
+              <span class="nav-menu__prompt" aria-hidden="true">&gt;</span>
+              Menú de páginas
+              <span class="material-symbols-outlined" aria-hidden="true">expand_more</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a role="menuitem" href="benefactores.html"><span class="nav-menu__command">cat</span> Benefactores</a>
+              <a class="active" role="menuitem" href="contactanos.html"><span class="nav-menu__command">ping</span> Contáctanos</a>
+              <a role="menuitem" href="politica_de_privacidad.html"><span class="nav-menu__command">less</span> Privacidad</a>
+              <a role="menuitem" href="terminos_de_servicio.html"><span class="nav-menu__command">man</span> Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -26,10 +26,19 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a href="contactanos.html">Contáctanos</a>
-          <a class="active" href="politica_de_privacidad.html">Privacidad</a>
-          <a href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary class="nav-menu__toggle">
+              <span class="nav-menu__prompt" aria-hidden="true">&gt;</span>
+              Menú de páginas
+              <span class="material-symbols-outlined" aria-hidden="true">expand_more</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a role="menuitem" href="benefactores.html"><span class="nav-menu__command">cat</span> Benefactores</a>
+              <a role="menuitem" href="contactanos.html"><span class="nav-menu__command">ping</span> Contáctanos</a>
+              <a class="active" role="menuitem" href="politica_de_privacidad.html"><span class="nav-menu__command">less</span> Privacidad</a>
+              <a role="menuitem" href="terminos_de_servicio.html"><span class="nav-menu__command">man</span> Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -26,10 +26,19 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Privacidad</a>
-          <a class="active" href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary class="nav-menu__toggle">
+              <span class="nav-menu__prompt" aria-hidden="true">&gt;</span>
+              Menú de páginas
+              <span class="material-symbols-outlined" aria-hidden="true">expand_more</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a role="menuitem" href="benefactores.html"><span class="nav-menu__command">cat</span> Benefactores</a>
+              <a role="menuitem" href="contactanos.html"><span class="nav-menu__command">ping</span> Contáctanos</a>
+              <a role="menuitem" href="politica_de_privacidad.html"><span class="nav-menu__command">less</span> Privacidad</a>
+              <a class="active" role="menuitem" href="terminos_de_servicio.html"><span class="nav-menu__command">man</span> Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>


### PR DESCRIPTION
### Motivation

- Reduce header clutter by consolidating multiple page links into a single compact menu.  
- Match the site’s command-line aesthetic with a terminal-style navigation affordance.  
- Improve discoverability of secondary pages while keeping the primary `Inicio` link prominent.

### Description

- Replace the inline page links in `index.html` and all static pages under `pages/` with a `<details class="nav-menu">` terminal-themed menu containing items labeled with command hints like `cat`, `ping`, `less`, and `man`.  
- Add accessible attributes (`role="menu"` and `role="menuitem"`) and visual prompts (`&gt;`) to the new menu markup.  
- Add styling and responsive behavior in `assets/css/style.css` for `.nav-menu`, `.nav-menu__toggle`, `.nav-menu__panel`, and `.nav-menu__command` including mobile layout adjustments.  
- Update headers across `index.html`, `pages/benefactores.html`, `pages/contactanos.html`, `pages/politica_de_privacidad.html`, and `pages/terminos_de_servicio.html` to use the consolidated menu.

### Testing

- Launched a local server with `python -m http.server` and verified pages load successfully.  
- Ran a Playwright script to open `http://127.0.0.1:8000/index.html` and capture a screenshot (`artifacts/menu.png`), which completed successfully.  
- No unit tests were added or run because changes are static HTML/CSS updates.  
- Manual visual verification via the generated screenshot confirmed the menu renders and expands as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695364d2be88832bade42a7972703c84)