### PR TITLE
Add hamburger menu for auxiliary pages

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -158,6 +158,67 @@ a:focus {
   border-color: var(--accent);
 }
 
+.nav-menu {
+  position: relative;
+}
+
+.nav-menu > summary {
+  list-style: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  padding-bottom: 4px;
+  border-bottom: 2px solid transparent;
+  color: inherit;
+}
+
+.nav-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.nav-menu[open] > summary,
+.nav-menu > summary:hover,
+.nav-menu > summary:focus-visible {
+  border-color: var(--accent);
+}
+
+.nav-menu__panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 10px);
+  min-width: 190px;
+  padding: 12px;
+  border-radius: 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: 0 12px 24px var(--shadow);
+  display: grid;
+  gap: 10px;
+  z-index: 10;
+}
+
+.nav-menu__panel a {
+  padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+}
+
+.nav-menu__panel a.active,
+.nav-menu__panel a:hover {
+  border-color: var(--accent);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .search {
   display: flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -26,10 +26,18 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a class="active" href="index.html">Inicio</a>
-          <a href="pages/benefactores.html">Benefactores</a>
-          <a href="pages/contactanos.html">Contáctanos</a>
-          <a href="pages/politica_de_privacidad.html">Privacidad</a>
-          <a href="pages/terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary aria-label="Abrir menú de páginas">
+              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+              <span class="sr-only">Menú</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a href="pages/benefactores.html">Benefactores</a>
+              <a href="pages/contactanos.html">Contáctanos</a>
+              <a href="pages/politica_de_privacidad.html">Privacidad</a>
+              <a href="pages/terminos_de_servicio.html">Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -26,10 +26,18 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a class="active" href="benefactores.html">Benefactores</a>
-          <a href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Privacidad</a>
-          <a href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary aria-label="Abrir menú de páginas">
+              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+              <span class="sr-only">Menú</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a class="active" href="benefactores.html">Benefactores</a>
+              <a href="contactanos.html">Contáctanos</a>
+              <a href="politica_de_privacidad.html">Privacidad</a>
+              <a href="terminos_de_servicio.html">Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -26,10 +26,18 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a class="active" href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Privacidad</a>
-          <a href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary aria-label="Abrir menú de páginas">
+              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+              <span class="sr-only">Menú</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a href="benefactores.html">Benefactores</a>
+              <a class="active" href="contactanos.html">Contáctanos</a>
+              <a href="politica_de_privacidad.html">Privacidad</a>
+              <a href="terminos_de_servicio.html">Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -26,10 +26,18 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a href="contactanos.html">Contáctanos</a>
-          <a class="active" href="politica_de_privacidad.html">Privacidad</a>
-          <a href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary aria-label="Abrir menú de páginas">
+              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+              <span class="sr-only">Menú</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a href="benefactores.html">Benefactores</a>
+              <a href="contactanos.html">Contáctanos</a>
+              <a class="active" href="politica_de_privacidad.html">Privacidad</a>
+              <a href="terminos_de_servicio.html">Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -26,10 +26,18 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Privacidad</a>
-          <a class="active" href="terminos_de_servicio.html">Términos</a>
+          <details class="nav-menu">
+            <summary aria-label="Abrir menú de páginas">
+              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
+              <span class="sr-only">Menú</span>
+            </summary>
+            <div class="nav-menu__panel" role="menu">
+              <a href="benefactores.html">Benefactores</a>
+              <a href="contactanos.html">Contáctanos</a>
+              <a href="politica_de_privacidad.html">Privacidad</a>
+              <a class="active" href="terminos_de_servicio.html">Términos</a>
+            </div>
+          </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="material-symbols-outlined" aria-hidden="true">search</span>


### PR DESCRIPTION
### Motivation
- Consolidate auxiliary page links into a compact hamburger menu that matches the site’s visual style.  
- Replace verbose/terminal-like text with a purely visual menu trigger that remains familiar to users.  
- Preserve visual active/hover states so the current page remains discoverable inside the menu.  

### Description
- Add CSS for the menu and panel (`.nav-menu`, `.nav-menu__panel`, and `.sr-only`) in `assets/css/style.css`.  
- Replace the inline auxiliary links in the header of `index.html` and the pages `pages/benefactores.html`, `pages/contactanos.html`, `pages/politica_de_privacidad.html`, and `pages/terminos_de_servicio.html` with a `<details class="nav-menu">` block that contains the links.  
- Keep `active` classes on page links inside the panel and reuse existing `var(--accent)` styling for hover/active states.  
- Use the Material Symbols `menu` icon and ensure the summary has an accessible label and focus/hover visuals.  

### Testing
- Started a local server using `python -m http.server 4173` to serve the site and the server started successfully.  
- Ran a Playwright visual smoke test that opened `http://127.0.0.1:4173/index.html`, clicked the menu `summary[aria-label="Abrir menú de páginas"]`, and captured a screenshot which was produced successfully.  
- No automated unit tests were executed for this static HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69536685e40c832b98391c617dd157c2)