### PR TITLE
Close nav menu when clicking outside

### DIFF
--- a/assets/js/nav-menu.js
+++ b/assets/js/nav-menu.js
@@ -1,0 +1,40 @@
+(() => {
+  const menus = Array.from(document.querySelectorAll('.nav-menu'));
+
+  if (!menus.length) {
+    return;
+  }
+
+  const closeMenu = (menu) => {
+    menu.removeAttribute('open');
+  };
+
+  document.addEventListener('click', (event) => {
+    menus.forEach((menu) => {
+      if (!menu.open) {
+        return;
+      }
+
+      if (menu.contains(event.target)) {
+        if (event.target.closest('.nav-menu__panel a')) {
+          closeMenu(menu);
+        }
+        return;
+      }
+
+      closeMenu(menu);
+    });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') {
+      return;
+    }
+
+    menus.forEach((menu) => {
+      if (menu.open) {
+        closeMenu(menu);
+      }
+    });
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -100,5 +100,6 @@
   </footer>
   <script src="assets/js/central-time.js"></script>
   <script src="assets/js/theme-toggle.js"></script>
+  <script src="assets/js/nav-menu.js"></script>
 </body>
 </html>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -103,5 +103,6 @@
   </footer>
   <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
 </body>
 </html>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -112,5 +112,6 @@
   </footer>
   <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
 </body>
 </html>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -111,5 +111,6 @@
   </footer>
   <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
 </body>
 </html>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -111,5 +111,6 @@
   </footer>
   <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Fix a UX issue where the expanded navigation menu (the `details.nav-menu`) did not close when the user clicked outside of it.
- Ensure the menu also collapses when the user presses `Escape` or selects a link inside the menu.
- Apply this behavior consistently across pages that use the shared navigation.

### Description
- Add a new script `assets/js/nav-menu.js` that queries `.nav-menu`, closes open menus on document `click` when the click is outside the menu or on a menu link, and closes menus on `Escape` key presses.
- Wire the new script into the site by adding `<script src="assets/js/nav-menu.js"></script>` to `index.html` and the affected pages under `pages/`.
- The script uses `menu.removeAttribute('open')` to collapse the native `details` element.

### Testing
- No automated tests were run for this change (static update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f59cdbe4832bb45efc63c620e01c)