### PR TITLE
Add post thumbnail to index stream

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -340,6 +340,15 @@ a:focus {
   gap: 12px;
 }
 
+.post__thumb {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  object-fit: cover;
+  aspect-ratio: 16 / 9;
+  box-shadow: 0 8px 18px var(--shadow);
+}
+
 .post__meta {
   display: flex;
   flex-wrap: wrap;

--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
       <h3 class="section-title">Stream de noticias</h3>
       <div id="stream" class="stream">
         <article class="post">
+          <img class="post__thumb" src="assets/img/ram-ia.png" alt="Ilustración de memoria y chips para el artículo La redefinición de lo “suficiente”" />
           <h4>La redefinición de lo “suficiente”</h4>
           <div class="post__meta">
             <span>2025-12-29</span>


### PR DESCRIPTION
### Motivation
- Improve the index stream visual by showing a thumbnail for each post to make entries more scannable.
- Use the existing image asset `assets/img/ram-ia.png` as the post visual to avoid adding new assets.
- Keep the thumbnail consistent with the card layout and theme styles.

### Description
- Added an `<img class="post__thumb" src="assets/img/ram-ia.png" alt="Ilustración de memoria y chips para el artículo La redefinición de lo “suficiente”" />` to the post card in `index.html`.
- Introduced `.post__thumb` rules in `assets/css/style.css` to set `width: 100%`, `aspect-ratio: 16/9`, `object-fit: cover`, `border-radius`, `border`, and `box-shadow` for consistent presentation.
- Modified files: `index.html` and `assets/css/style.css`.

### Testing
- Started a local server with `python -m http.server 8000` and captured a page screenshot using Playwright, producing `artifacts/index-thumbnail.png`, which completed successfully.
- No unit or CI tests were added or run for this static layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953f94bd140832bbaf5617bf48a4417)