### PR TITLE
Remove extra hero card button

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,6 @@
           </p>
           <div class="post__actions">
             <a class="button" href="posts/menos-ram-mas-discurso.html">Leer artículo</a>
-            <a class="button secondary" href="pages/politica_de_privacidad.html">Cómo trabajamos</a>
           </div>
         </article>
       </div>


### PR DESCRIPTION
### Motivation
- The hero post card displayed a secondary "Cómo trabajamos" button that looked out of place for the featured post. 
- The intent is to simplify the hero card actions to only include the primary `Leer artículo` link. 

### Description
- Removed the secondary `<a class="button secondary" href="pages/politica_de_privacidad.html">Cómo trabajamos</a>` element from `index.html` inside the hero card `post__actions` container. 
- Committed the change and kept the rest of the page structure intact to preserve layout and accessibility. 
- Generated a visual snapshot of the updated hero card at `artifacts/hero-card.png` for verification. 

### Testing
- Served the site locally with `python -m http.server 8000` which started successfully. 
- Ran a Playwright script that loaded `http://127.0.0.1:8000/index.html` and captured `artifacts/hero-card.png`, confirming the button is gone. 
- No unit tests were applicable for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953fa6b2e8c832b83e5f2dca7810e8b)