### PR TITLE
Adopt new light visual style with command-style header and search

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,4 +1,24 @@
-:root {
+:root,
+[data-theme="light"] {
+  color-scheme: light;
+  --bg: #f6efe6;
+  --panel: #fdf8f1;
+  --text: #2c261e;
+  --muted: #756753;
+  --accent: #d98321;
+  --accent-strong: #b76916;
+  --border: #e4d6c4;
+  --shadow: rgba(60, 44, 24, 0.12);
+  --page-bg: #f6efe6;
+  --post-bg: #ffffff;
+  --callout-bg: #fff2dc;
+  --button-bg: #14110c;
+  --button-text: #f8f1e6;
+  --button-secondary-text: #d98321;
+  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+[data-theme="dark"] {
   color-scheme: dark;
   --bg: #100e08;
   --panel: #18140b;
@@ -11,22 +31,9 @@
   --page-bg: radial-gradient(circle at top, #1a150b, #0c0a06 60%);
   --post-bg: rgba(18, 15, 9, 0.9);
   --callout-bg: rgba(242, 193, 76, 0.08);
-  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-}
-
-[data-theme="light"] {
-  color-scheme: light;
-  --bg: #f7f3e8;
-  --panel: #ffffff;
-  --text: #2b2415;
-  --muted: #6c5f3a;
-  --accent: #d88b1f;
-  --accent-strong: #b96b0b;
-  --border: #e4d9bb;
-  --shadow: rgba(54, 40, 13, 0.12);
-  --page-bg: radial-gradient(circle at top, #fdfaf4, #efe7d5 65%);
-  --post-bg: #fdf9f0;
-  --callout-bg: rgba(216, 139, 31, 0.12);
+  --button-bg: #2a1f05;
+  --button-text: #f5e7bf;
+  --button-secondary-text: #f2c14c;
 }
 
 * {
@@ -71,24 +78,28 @@ a:focus {
 }
 
 .site-header {
-  padding: 24px 0 16px;
+  padding: 16px 0 20px;
   border-bottom: 1px solid var(--border);
 }
 
 .header-top {
   display: flex;
-  justify-content: flex-end;
-  margin-bottom: 12px;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 18px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--muted);
 }
 
 .central-clock {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.85rem;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-size: 0.75rem;
 }
 
 .central-clock__label {
@@ -109,12 +120,12 @@ a:focus {
 .brand__badge {
   background: var(--accent);
   color: #2a1f05;
-  padding: 8px 14px;
-  border-radius: 4px;
+  padding: 10px 16px;
+  border-radius: 2px;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -144,12 +155,14 @@ a:focus {
 .nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 18px;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .nav a {
-  padding-bottom: 4px;
+  padding-bottom: 6px;
   border-bottom: 2px solid transparent;
 }
 
@@ -168,7 +181,7 @@ a:focus {
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  padding-bottom: 4px;
+  padding-bottom: 6px;
   border-bottom: 2px solid transparent;
   color: inherit;
 }
@@ -189,7 +202,7 @@ a:focus {
   top: calc(100% + 10px);
   min-width: 190px;
   padding: 12px;
-  border-radius: 8px;
+  border-radius: 10px;
   background: var(--panel);
   border: 1px solid var(--border);
   box-shadow: 0 12px 24px var(--shadow);
@@ -222,11 +235,12 @@ a:focus {
 .search {
   display: flex;
   align-items: center;
-  gap: 8px;
-  background: var(--panel);
-  border: 1px solid var(--border);
-  padding: 8px 12px;
-  border-radius: 6px;
+  gap: 10px;
+  background: var(--post-bg);
+  border: 2px solid #d5d0c7;
+  padding: 10px 14px;
+  border-radius: 8px;
+  box-shadow: 0 6px 12px rgba(55, 45, 30, 0.08);
 }
 
 .search input {
@@ -241,11 +255,11 @@ a:focus {
 .theme-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  padding: 6px 10px;
-  border-radius: 999px;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 10px;
   border: 1px solid var(--border);
-  background: var(--panel);
+  background: var(--post-bg);
   color: var(--text);
   font-weight: 600;
   cursor: pointer;
@@ -262,37 +276,11 @@ a:focus {
 }
 
 .theme-toggle__switch {
-  width: 42px;
-  height: 22px;
-  border-radius: 999px;
-  background: var(--border);
-  position: relative;
-  transition: background 0.2s ease;
-}
-
-.theme-toggle__switch::after {
-  content: "";
-  position: absolute;
-  top: 3px;
-  left: 3px;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--accent);
-  transition: transform 0.2s ease;
-}
-
-[data-theme="light"] .theme-toggle__switch {
-  background: var(--accent);
-}
-
-[data-theme="light"] .theme-toggle__switch::after {
-  transform: translateX(20px);
-  background: var(--panel);
+  display: none;
 }
 
 .hero {
-  padding: 36px 0;
+  padding: 30px 0 24px;
 }
 
 .hero__grid {
@@ -303,11 +291,11 @@ a:focus {
 }
 
 .hero__card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 20px;
-  box-shadow: 0 10px 28px var(--shadow);
+  background: var(--post-bg);
+  border: 2px solid var(--accent);
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 14px 24px rgba(76, 58, 32, 0.12);
 }
 
 .hero__card h2 {
@@ -318,11 +306,24 @@ a:focus {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: var(--accent);
-  letter-spacing: 0.12em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
   margin-bottom: 10px;
+  padding: 4px 10px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+}
+
+.badge::before {
+  content: "[";
+  margin-right: 4px;
+}
+
+.badge::after {
+  content: "]";
+  margin-left: 4px;
 }
 
 .stream {
@@ -378,17 +379,20 @@ a:focus {
 }
 
 .button {
-  border: 1px solid var(--accent);
-  color: #2a1f05;
-  background: var(--accent);
-  padding: 6px 14px;
-  border-radius: 6px;
+  border: 1px solid var(--button-bg);
+  color: var(--button-text);
+  background: var(--button-bg);
+  padding: 10px 18px;
+  border-radius: 10px;
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .button.secondary {
   background: transparent;
-  color: var(--accent);
+  color: var(--button-secondary-text);
+  border-color: var(--accent);
 }
 
 .section-title {
@@ -470,6 +474,24 @@ a:focus {
   padding: 16px;
   border-radius: 8px;
   color: var(--text);
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+  background: var(--accent);
+}
+
+.status-dot--ok {
+  background: #4fbf72;
+}
+
+.search__prompt {
+  color: var(--accent);
+  font-weight: 700;
+  letter-spacing: 0.08em;
 }
 
 @media (max-width: 720px) {

--- a/index.html
+++ b/index.html
@@ -12,9 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock" aria-live="polite">
-          <span class="central-clock__label">Central</span>
-          <time class="central-clock__time" data-central-time></time>
+        <div class="central-clock">
+          <span class="central-clock__label">SYS.ONLINE</span>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">CONECTADO</span>
         </div>
       </div>
       <div class="brand">
@@ -40,8 +43,8 @@
           </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Escribe un tema o palabra clave" />
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar_comando..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -12,9 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock" aria-live="polite">
-          <span class="central-clock__label">Central</span>
-          <time class="central-clock__time" data-central-time></time>
+        <div class="central-clock">
+          <span class="central-clock__label">SYS.ONLINE</span>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">CONECTADO</span>
         </div>
       </div>
       <div class="brand">
@@ -40,8 +43,8 @@
           </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Escribe un tema o palabra clave" />
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar_comando..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -12,9 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock" aria-live="polite">
-          <span class="central-clock__label">Central</span>
-          <time class="central-clock__time" data-central-time></time>
+        <div class="central-clock">
+          <span class="central-clock__label">SYS.ONLINE</span>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">CONECTADO</span>
         </div>
       </div>
       <div class="brand">
@@ -40,8 +43,8 @@
           </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Escribe un tema o palabra clave" />
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar_comando..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -12,9 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock" aria-live="polite">
-          <span class="central-clock__label">Central</span>
-          <time class="central-clock__time" data-central-time></time>
+        <div class="central-clock">
+          <span class="central-clock__label">SYS.ONLINE</span>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">CONECTADO</span>
         </div>
       </div>
       <div class="brand">
@@ -40,8 +43,8 @@
           </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Escribe un tema o palabra clave" />
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar_comando..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -12,9 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock" aria-live="polite">
-          <span class="central-clock__label">Central</span>
-          <time class="central-clock__time" data-central-time></time>
+        <div class="central-clock">
+          <span class="central-clock__label">SYS.ONLINE</span>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">CONECTADO</span>
         </div>
       </div>
       <div class="brand">
@@ -40,8 +43,8 @@
           </details>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Escribe un tema o palabra clave" />
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar_comando..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>


### PR DESCRIPTION
### Motivation
- Move the default visual language to a lighter, beige-forward theme and simplify theme handling with explicit `data-theme` states.
- Give the site header a compact, status-oriented treatment (SYS.ONLINE / CONECTADO) and introduce a command-line style search prompt to match the new aesthetic.
- Refresh components (badges, buttons, cards, search, header spacing) to create a cohesive, modern look across pages.

### Description
- Reworked root variables and theming by making the light palette the default (`:root, [data-theme="light"]`) and adding a `data-theme="dark"` block, plus new button variables like `--button-bg` and `--button-text` in `assets/css/style.css`.
- Restyled header and header-top layout (spacing, uppercase meta, central status) and replaced the live central time element with `SYS.ONLINE` + `.status-dot` in `index.html` and all pages under `pages/`.
- Replaced the magnifying-glass UI with a command-style prompt (`.search__prompt` showing `>_`) and updated the search `input` placeholder to `buscar_comando...` across pages.
- Updated component styles: cards (`.hero__card`), badges (added `::before`/`::after` brackets), buttons (`.button` / `.button.secondary`), theme toggle (removed visible switch knob), and added `.status-dot` classes for status indicators in `assets/css/style.css`.

### Testing
- Launched a local static server with `python -m http.server 8000` and the server started successfully.
- Ran a Playwright script to render the homepage and capture a screenshot, which completed and produced `artifacts/anxina-style.png`.
- Verified the modified pages (`index.html` and files in `pages/`) load with the updated header and search markup in the browser snapshot.
- No unit tests exist for static HTML/CSS changes, and no additional automated test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695406693e34832b8c452bcf926c1ed0)