### PR TITLE
Make navbar a single-line horizontal menu and add './' active-page indicator

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -154,21 +154,34 @@ a:focus {
 
 .nav {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 18px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  white-space: nowrap;
+  overflow-x: auto;
+  padding-bottom: 2px;
 }
 
 .nav a {
+  display: inline-flex;
+  align-items: center;
   padding-bottom: 6px;
   border-bottom: 2px solid transparent;
+  color: var(--muted);
 }
 
 .nav a.active,
 .nav a:hover {
   border-color: var(--accent);
+  color: var(--accent);
+}
+
+.nav a.active::before {
+  content: "./";
+  margin-right: 4px;
+  color: var(--accent);
 }
 
 .nav-menu {

--- a/index.html
+++ b/index.html
@@ -28,19 +28,11 @@
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
-          <a class="active" href="index.html">Inicio</a>
-          <details class="nav-menu">
-            <summary aria-label="Abrir menú de páginas">
-              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
-              <span class="sr-only">Menú</span>
-            </summary>
-            <div class="nav-menu__panel" role="menu">
-              <a href="pages/benefactores.html">Benefactores</a>
-              <a href="pages/contactanos.html">Contáctanos</a>
-              <a href="pages/politica_de_privacidad.html">Privacidad</a>
-              <a href="pages/terminos_de_servicio.html">Términos</a>
-            </div>
-          </details>
+          <a class="active" href="index.html" aria-current="page">Inicio</a>
+          <a href="pages/contactanos.html">Contáctanos</a>
+          <a href="pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="pages/benefactores.html">Benefactores</a>
+          <a href="pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -29,18 +29,10 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <details class="nav-menu">
-            <summary aria-label="Abrir menú de páginas">
-              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
-              <span class="sr-only">Menú</span>
-            </summary>
-            <div class="nav-menu__panel" role="menu">
-              <a class="active" href="benefactores.html">Benefactores</a>
-              <a href="contactanos.html">Contáctanos</a>
-              <a href="politica_de_privacidad.html">Privacidad</a>
-              <a href="terminos_de_servicio.html">Términos</a>
-            </div>
-          </details>
+          <a href="contactanos.html">Contáctanos</a>
+          <a href="politica_de_privacidad.html">Política de privacidad</a>
+          <a class="active" href="benefactores.html" aria-current="page">Benefactores</a>
+          <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -29,18 +29,10 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <details class="nav-menu">
-            <summary aria-label="Abrir menú de páginas">
-              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
-              <span class="sr-only">Menú</span>
-            </summary>
-            <div class="nav-menu__panel" role="menu">
-              <a href="benefactores.html">Benefactores</a>
-              <a class="active" href="contactanos.html">Contáctanos</a>
-              <a href="politica_de_privacidad.html">Privacidad</a>
-              <a href="terminos_de_servicio.html">Términos</a>
-            </div>
-          </details>
+          <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
+          <a href="politica_de_privacidad.html">Política de privacidad</a>
+          <a href="benefactores.html">Benefactores</a>
+          <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -29,18 +29,10 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <details class="nav-menu">
-            <summary aria-label="Abrir menú de páginas">
-              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
-              <span class="sr-only">Menú</span>
-            </summary>
-            <div class="nav-menu__panel" role="menu">
-              <a href="benefactores.html">Benefactores</a>
-              <a href="contactanos.html">Contáctanos</a>
-              <a class="active" href="politica_de_privacidad.html">Privacidad</a>
-              <a href="terminos_de_servicio.html">Términos</a>
-            </div>
-          </details>
+          <a href="contactanos.html">Contáctanos</a>
+          <a class="active" href="politica_de_privacidad.html" aria-current="page">Política de privacidad</a>
+          <a href="benefactores.html">Benefactores</a>
+          <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -29,18 +29,10 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <details class="nav-menu">
-            <summary aria-label="Abrir menú de páginas">
-              <span class="material-symbols-outlined" aria-hidden="true">menu</span>
-              <span class="sr-only">Menú</span>
-            </summary>
-            <div class="nav-menu__panel" role="menu">
-              <a href="benefactores.html">Benefactores</a>
-              <a href="contactanos.html">Contáctanos</a>
-              <a href="politica_de_privacidad.html">Privacidad</a>
-              <a class="active" href="terminos_de_servicio.html">Términos</a>
-            </div>
-          </details>
+          <a href="contactanos.html">Contáctanos</a>
+          <a href="politica_de_privacidad.html">Política de privacidad</a>
+          <a href="benefactores.html">Benefactores</a>
+          <a class="active" href="terminos_de_servicio.html" aria-current="page">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -25,10 +25,10 @@
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
+          <a class="active" href="../index.html" aria-current="page">Inicio</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Privacidad</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
           <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">


### PR DESCRIPTION
### Motivation
- Replace the dropdown/stacking nav with a single horizontal row so the nav always appears on one line across pages.  
- Provide a clear active-page marker using the `./` prefix and accent color to indicate the current page.  
- Keep labels consistent (Inicio, Contáctanos, Política de privacidad, Benefactores, Términos) and improve accessibility with `aria-current` on the active link.

### Description
- Replaced the `<details>` dropdown with inline `<a>` links in `index.html`, `pages/*.html`, and `posts/*.html` so navigation is a flat horizontal list.  
- Added `aria-current="page"` to the active link elements for improved semantics.  
- Updated `assets/css/style.css` to enforce one-line layout with `flex-wrap: nowrap`, `white-space: nowrap`, `overflow-x: auto`, and adjusted link styles to use `display: inline-flex` and muted/default color.  
- Implemented the active-page indicator by styling `.nav a.active::before` to show the `./` prefix and apply `var(--accent)` color.

### Testing
- Launched a local static server with `python -m http.server` and served the site successfully.  
- Captured a full-page screenshot with a Playwright script to verify the updated navbar (artifact: `artifacts/nav-update.png`) and it completed successfully.  
- No automated unit tests were applicable to these static HTML/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954160d612c832ba62642755060d726)