### PR TITLE
Align post search styling with site header

### DIFF
--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -32,8 +32,8 @@
           <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
-          <span class="material-symbols-outlined" aria-hidden="true">search</span>
-          <input type="search" placeholder="Escribe un tema o palabra clave" />
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar_comando..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>


### PR DESCRIPTION
### Motivation
- The search control in the post header used a different icon and placeholder than the rest of the site, causing a visual inconsistency.
- The change aims to make the post page search match the global header styling and affordance.
- Keeping markup consistent simplifies maintenance and ensures a uniform user experience.

### Description
- Replaced the Material Icons search span with the site prompt span ` <span class="search__prompt">&gt;_</span>` to match other pages.
- Updated the search `input` placeholder from `Escribe un tema o palabra clave` to `buscar_comando...` to match the site convention.
- The edit was applied to `posts/menos-ram-mas-discurso.html` and is strictly an HTML change with no CSS modifications.

### Testing
- Launched a local static server with `python -m http.server 8000` and it started successfully.
- Ran a Playwright script to load `http://127.0.0.1:8000/posts/menos-ram-mas-discurso.html` and captured a screenshot of the updated header, which succeeded and produced an artifact.
- No unit or integration test suite was run because this is a static HTML markup change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695418e38818832bb359f0940b0988cc)