### PR TITLE
Remove uppercase transform from brand badge

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -124,7 +124,6 @@ a:focus {
   border-radius: 2px;
   font-weight: 700;
   letter-spacing: 0.12em;
-  text-transform: uppercase;
   font-size: 0.9rem;
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Motivation
- Preserve mixed-case branding by preventing forced uppercase on badge text across layouts including posts.

### Description
- Removed the `text-transform: uppercase;` declaration from `.brand__badge` in `assets/css/style.css`.
- All other badge styling such as `font-weight`, `letter-spacing`, and sizing are left unchanged.

### Testing
- No automated tests were run for this CSS-only change.
- There are no unit tests associated with this styling modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69541ed434c8832b9bd11b5c69379c29)