### PR TITLE
Remove 'comando' from search input placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar_comando..." />
+          <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -36,7 +36,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar_comando..." />
+          <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -36,7 +36,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar_comando..." />
+          <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -36,7 +36,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar_comando..." />
+          <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -36,7 +36,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar_comando..." />
+          <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -33,7 +33,7 @@
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar_comando..." />
+          <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>


### PR DESCRIPTION
### Motivation
- The search input placeholder contained the word `comando`, which may be confusing to readers. 
- Simplify the UX by using a shorter, language-appropriate prompt for search inputs. 

### Description
- Replaced the placeholder `buscar_comando...` with `buscar...` in six HTML files. 
- Files changed: `index.html`, `posts/menos-ram-mas-discurso.html`, `pages/benefactores.html`, `pages/contactanos.html`, `pages/politica_de_privacidad.html`, and `pages/terminos_de_servicio.html`. 
- This is a static content change; no JavaScript or backend logic was modified. 

### Testing
- Served the site locally with `python -m http.server 8000` and verified rendering of `index.html` using a Playwright script, which captured a screenshot artifact successfully. 
- No unit tests were required for this static text update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695438884b18832b8cfc44207600214a)