### PR TITLE
Add "ANXiNA paso en 2025" post entry to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,22 @@
       <h3 class="section-title">Stream de noticias</h3>
       <div id="stream" class="stream">
         <article class="post">
+          <img class="post__thumb" src="assets/img/2025anxina.png" alt="Composición editorial sobre el año 2025 en tecnología y cultura" />
+          <h4>ANXiNA paso en 2025</h4>
+          <div class="post__meta">
+            <span>2025-12-31</span>
+            <span>Tepokato · Tecnología</span>
+          </div>
+          <p>El balance de lo mejor y lo más importante de 2025 en tecnología, ciencia y cultura.</p>
+          <div class="post__tags">
+            <span>#tecnologia</span>
+            <span>#ciencia</span>
+          </div>
+          <div class="post__actions">
+            <a class="button" href="posts/anxina_paso_en_2025.html">Leer artículo</a>
+          </div>
+        </article>
+        <article class="post">
           <img class="post__thumb" src="assets/img/ram-ia.png" alt="Ilustración de memoria y chips para el artículo La redefinición de lo “suficiente”" />
           <h4>La redefinición de lo “suficiente”</h4>
           <div class="post__meta">


### PR DESCRIPTION
### Motivation
- Surface the new “ANXiNA paso en 2025” article in the homepage stream so visitors can discover the year-in-review piece. 
- Include a thumbnail, metadata and tags to match existing post cards and provide a direct link to the full article. 

### Description
- Updated `index.html` to insert a new `<article class="post">` card for the `posts/anxina_paso_en_2025.html` entry. 
- The new card includes the thumbnail `assets/img/2025anxina.png`, date and author metadata, category and tags, and a `Leer artículo` link. 
- No other files were changed; the modification is a static HTML addition and was committed.

### Testing
- Launched a local static server with `python -m http.server` and used a Playwright script to load `/index.html` and capture a full-page screenshot, which completed successfully. 
- No unit tests were applicable for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69555f5f3e78832bb2193ce32e631ee3)