### PR TITLE
Position hero badge over background

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -312,6 +312,7 @@ a:focus {
   grid-template-columns: auto 1fr;
   gap: 20px;
   align-items: start;
+  position: relative;
 }
 
 .hero__thumb {
@@ -344,6 +345,14 @@ a:focus {
   padding: 4px 10px;
   border: 1px solid var(--accent);
   border-radius: 6px;
+}
+
+.hero__card .badge {
+  position: absolute;
+  top: 18px;
+  left: 18px;
+  z-index: 2;
+  background: var(--page-bg);
 }
 
 .badge::before {


### PR DESCRIPTION
### Motivation
- Ensure the "En portada" badge in the hero card overlays the card background similar to the `Stream de noticias` items.
- Improve badge legibility when it sits on top of the hero image and card border.

### Description
- Added `position: relative` to `.hero__card` to establish a containing block for absolutely positioned children.
- Introduced `.hero__card .badge` rules to set `position: absolute`, `top: 18px`, `left: 18px`, `z-index: 2`, and `background: var(--page-bg)` so the badge sits above the hero artwork.
- This is a CSS-only change in `assets/css/style.css` with no markup updates.

### Testing
- Launched a local server with `python -m http.server 8000` and the site served successfully.
- Ran a Playwright script that loaded `index.html` and produced a screenshot at `artifacts/en-portada-badge.png` confirming the badge overlays the hero card.
- No unit tests were applicable for this visual/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695574d1d794832b9862ee6f7fd26c42)