### PR TITLE
Match hero badge styling to section title

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -346,6 +346,19 @@ a:focus {
   border-radius: 6px;
 }
 
+.hero__card .badge {
+  border: none;
+  padding: 0;
+  margin: 0 0 8px;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+}
+
+.hero__card .badge::before,
+.hero__card .badge::after {
+  content: none;
+}
+
 .badge::before {
   content: "[";
   margin-right: 4px;


### PR DESCRIPTION
### Motivation
- Make the hero "En portada" badge match the visual treatment and inline behavior of the `Stream de noticias` section title.
- Improve badge legibility and consistent spacing when it appears above the hero content.

### Description
- Replace the absolute-positioned hero badge rules with inline-style overrides in `.hero__card .badge` to remove positioning and adjust spacing and font properties.
- Disable the bracket pseudo-elements for the hero badge by setting `.hero__card .badge::before` and `.hero__card .badge::after` to `content: none`.
- Preserve the shared base `.badge` rules so other badges retain their common appearance.

### Testing
- Launched a local server with `python -m http.server 8000` and confirmed the site served successfully.
- Ran a Playwright script that loaded `index.html` and produced a screenshot at `artifacts/en-portada-inline.png`, which shows the badge inline above the hero title as intended.
- An initial Playwright run targeting port `8001` failed to connect, but the subsequent automated run against port `8000` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695574d1d794832b9862ee6f7fd26c42)