### PR TITLE
Unify header layout across HTML pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,13 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock">
-          <span class="central-clock__label">SYS.ONLINE</span>
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
         </div>
         <div class="central-clock">
           <span class="status-dot status-dot--ok" aria-hidden="true"></span>
-          <span class="central-clock__label">CONECTADO</span>
+          <span class="central-clock__label">Conectado</span>
         </div>
       </div>
       <div class="brand">

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -12,12 +12,13 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock">
-          <span class="central-clock__label">SYS.ONLINE</span>
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
         </div>
         <div class="central-clock">
           <span class="status-dot status-dot--ok" aria-hidden="true"></span>
-          <span class="central-clock__label">CONECTADO</span>
+          <span class="central-clock__label">Conectado</span>
         </div>
       </div>
       <div class="brand">

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -12,12 +12,13 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock">
-          <span class="central-clock__label">SYS.ONLINE</span>
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
         </div>
         <div class="central-clock">
           <span class="status-dot status-dot--ok" aria-hidden="true"></span>
-          <span class="central-clock__label">CONECTADO</span>
+          <span class="central-clock__label">Conectado</span>
         </div>
       </div>
       <div class="brand">

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -12,12 +12,13 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock">
-          <span class="central-clock__label">SYS.ONLINE</span>
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
         </div>
         <div class="central-clock">
           <span class="status-dot status-dot--ok" aria-hidden="true"></span>
-          <span class="central-clock__label">CONECTADO</span>
+          <span class="central-clock__label">Conectado</span>
         </div>
       </div>
       <div class="brand">

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -12,12 +12,13 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="central-clock">
-          <span class="central-clock__label">SYS.ONLINE</span>
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
         </div>
         <div class="central-clock">
           <span class="status-dot status-dot--ok" aria-hidden="true"></span>
-          <span class="central-clock__label">CONECTADO</span>
+          <span class="central-clock__label">Conectado</span>
         </div>
       </div>
       <div class="brand">

--- a/posts/anxina_paso_en_2025.html
+++ b/posts/anxina_paso_en_2025.html
@@ -16,6 +16,10 @@
           <span class="central-clock__label">Central</span>
           <time class="central-clock__time" data-central-time></time>
         </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
       </div>
       <div class="brand">
         <div class="brand__badge">
@@ -25,7 +29,7 @@
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
-          <a class="active" href="../index.html" aria-current="page">Inicio</a>
+          <a href="../index.html">Inicio</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
           <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
           <a href="../pages/benefactores.html">Benefactores</a>
@@ -194,5 +198,6 @@
   </footer>
   <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
 </body>
 </html>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -16,6 +16,10 @@
           <span class="central-clock__label">Central</span>
           <time class="central-clock__time" data-central-time></time>
         </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
       </div>
       <div class="brand">
         <div class="brand__badge">
@@ -25,7 +29,7 @@
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
-          <a class="active" href="../index.html" aria-current="page">Inicio</a>
+          <a href="../index.html">Inicio</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
           <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
           <a href="../pages/benefactores.html">Benefactores</a>
@@ -127,5 +131,6 @@
   </footer>
   <script src="../assets/js/central-time.js"></script>
   <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation

- Standardize the header top region across all site HTML files so the central clock and connection status are consistent.
- Replace inconsistent labels (e.g. `SYS.ONLINE` / `CONECTADO`) with a single `Central` clock element that updates via `data-central-time`.
- Remove incorrect active navigation state on individual post pages to avoid misleading UI highlighting.
- Ensure post pages include the same navigation behavior by adding the `nav-menu.js` script.

### Description

- Updated the `header-top` block in `index.html`, `pages/*.html` and `posts/*.html` to include `<time class="central-clock__time" data-central-time>` and `aria-live="polite"` for the clock.
- Normalized the connection text to `Conectado` and added the status dot element in all headers.
- Removed the stray `class="active"` from the `Inicio` link in post pages to fix incorrect active state.
- Added `<script src="../assets/js/nav-menu.js"></script>` to post pages so navigation behavior matches the rest of the site.

### Testing

- Served the site locally with `python -m http.server 8000` and confirmed the server started successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/index.html` and captured a full-page screenshot (`artifacts/anxina-header.png`) to verify header rendering, which completed successfully.
- No unit tests were required since these are static HTML/CSS/JS parity changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e21122a0832b82dd577d6f7107f4)