### PR TITLE
Make card thumbnails and titles clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,10 +51,14 @@
     <section class="hero">
       <div class="container hero__grid">
         <article class="hero__card">
-          <img class="hero__thumb" src="assets/img/ram-ia.png" alt="Detalle de memoria y chips en miniatura" />
+          <a href="posts/menos-ram-mas-discurso.html">
+            <img class="hero__thumb" src="assets/img/ram-ia.png" alt="Detalle de memoria y chips en miniatura" />
+          </a>
           <div class="hero__content">
             <div class="badge">En portada</div>
-            <h2>La redefinición de lo “suficiente”</h2>
+            <h2>
+              <a class="post__title-link" href="posts/menos-ram-mas-discurso.html">La redefinición de lo “suficiente”</a>
+            </h2>
             <p>
               Menos RAM para ti. Más memoria para la IA. Un análisis sobre cómo el discurso cambia cuando los costos
               se disparan y la memoria se vuelve un recurso cada vez más disputado.
@@ -71,9 +75,13 @@
       <h3 class="section-title">Stream de noticias</h3>
       <div id="stream" class="stream">
         <article class="post post--compact">
-          <img class="post__thumb" src="assets/img/2025anxina.png" alt="Composición editorial sobre el año 2025 en tecnología y cultura" />
+          <a href="posts/anxina_paso_en_2025.html">
+            <img class="post__thumb" src="assets/img/2025anxina.png" alt="Composición editorial sobre el año 2025 en tecnología y cultura" />
+          </a>
           <div class="post__body">
-            <h4>ANXiNA paso en 2025</h4>
+            <h4>
+              <a class="post__title-link" href="posts/anxina_paso_en_2025.html">ANXiNA paso en 2025</a>
+            </h4>
             <div class="post__meta">
               <span>2025-12-31</span>
               <span>Tepokato · Tecnología</span>
@@ -89,9 +97,13 @@
           </div>
         </article>
         <article class="post post--compact">
-          <img class="post__thumb" src="assets/img/ram-ia.png" alt="Ilustración de memoria y chips para el artículo La redefinición de lo “suficiente”" />
+          <a href="posts/menos-ram-mas-discurso.html">
+            <img class="post__thumb" src="assets/img/ram-ia.png" alt="Ilustración de memoria y chips para el artículo La redefinición de lo “suficiente”" />
+          </a>
           <div class="post__body">
-            <h4>La redefinición de lo “suficiente”</h4>
+            <h4>
+              <a class="post__title-link" href="posts/menos-ram-mas-discurso.html">La redefinición de lo “suficiente”</a>
+            </h4>
             <div class="post__meta">
               <span>2025-12-29</span>
               <span>Tepokato · IA</span>


### PR DESCRIPTION
### Motivation

- Thumbnails and post titles should perform the same action as the "Leer artículo" button to improve discoverability and affordance.
- Ensure users can navigate to articles by clicking either the image or the headline for both the hero and stream cards.

### Description

- Wrapped card thumbnail images in anchor tags linking to their article pages in `index.html`.
- Replaced plain headings with linked headings using an `<a class="post__title-link">` that points to the same URL as each card's `Leer artículo` button.
- Applied the changes to the hero card and all `post--compact` entries in the main stream.

### Testing

- Served the site locally with `python -m http.server 8000` and loaded `index.html` to validate links were present.
- Ran a Playwright smoke test that loaded the page and captured `artifacts/cards-clickable.png`, which completed successfully.
- No unit tests were executed for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956e4b727e8832b820a2e4ff5707b9b)