### PR TITLE
Update stream news card layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -372,6 +372,7 @@ a:focus {
 .stream {
   display: grid;
   gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   padding-bottom: 40px;
 }
 
@@ -385,14 +386,13 @@ a:focus {
 }
 
 .post--compact {
-  grid-template-columns: auto 1fr;
-  gap: 18px;
-  align-items: start;
+  grid-template-columns: 1fr;
+  gap: 14px;
 }
 
 .post--compact .post__body {
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
 
 .post__thumb {
@@ -405,9 +405,9 @@ a:focus {
 }
 
 .post--compact .post__thumb {
-  width: 140px;
-  height: 140px;
-  aspect-ratio: 1;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
 }
 
 .post__meta {
@@ -436,6 +436,22 @@ a:focus {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.post__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.post__link {
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
 }
 
 .button {
@@ -632,8 +648,6 @@ a:focus {
 
   .post--compact .post__thumb {
     width: 100%;
-    height: auto;
-    aspect-ratio: 16 / 9;
   }
 
   .post__actions {

--- a/index.html
+++ b/index.html
@@ -88,12 +88,12 @@
               <span>Tepokato · Tecnología</span>
             </div>
             <p>2025 fue un año de ruido, promesas infladas y decisiones que sí importaron. En ANXiNA repasamos los mejores teléfonos calidad-precio, las series y películas que realmente dejaron huella, y las noticias de tecnología, ciencia y videojuegos que marcaron a Latinoamérica.</p>
-            <div class="post__tags">
-              <span>#tecnologia</span>
-              <span>#entretenimiento</span>
-            </div>
-            <div class="post__actions">
-              <a class="button" href="posts/anxina-paso-en-2025.html">Leer artículo</a>
+            <div class="post__footer">
+              <div class="post__tags">
+                <span>#tecnologia</span>
+                <span>#entretenimiento</span>
+              </div>
+              <a class="post__link" href="posts/anxina-paso-en-2025.html">Leer artículo</a>
             </div>
           </div>
         </article>
@@ -110,11 +110,11 @@
               <span>Tepokato · IA</span>
             </div>
             <p>Menos RAM para ti. Más memoria para la IA.</p>
-            <div class="post__tags">
-              <span>#ia</span>
-            </div>
-            <div class="post__actions">
-              <a class="button" href="posts/menos-ram-mas-discurso.html">Leer artículo</a>
+            <div class="post__footer">
+              <div class="post__tags">
+                <span>#ia</span>
+              </div>
+              <a class="post__link" href="posts/menos-ram-mas-discurso.html">Leer artículo</a>
             </div>
           </div>
         </article>

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -146,11 +146,11 @@ STREAM_ITEM_TEMPLATE = """        <article class="post post--compact">
               <span>{author} · {category}</span>
             </div>
             <p>{summary}</p>
-            <div class="post__tags">
+            <div class="post__footer">
+              <div class="post__tags">
 {tags}
-            </div>
-            <div class="post__actions">
-              <a class="button" href="posts/{slug}.html">Leer artículo</a>
+              </div>
+              <a class="post__link" href="posts/{slug}.html">Leer artículo</a>
             </div>
           </div>
         </article>"""


### PR DESCRIPTION
### Motivation
- Modernize the "Stream de noticias" cards to an image-first, vertical layout that matches the site’s visual language.
- Surface article tags and the call-to-action together for clearer affordance and consistent spacing.
- Make the stream responsive so cards reflow into a grid on wider viewports while remaining vertical on smaller screens.

### Description
- Change the post markup to wrap tags and the CTA into a single footer by adding `post__footer` and replacing the previous `post__actions`/`post__tags` placement in `index.html` and the `STREAM_ITEM_TEMPLATE` in `scripts/build_posts.py`.
- Update `assets/css/style.css` to use `grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))` for `.stream`, switch `.post--compact` to a single-column vertical layout, and add styles for `.post__footer` and `.post__link`.
- Adjust thumbnail sizing and aspect-ratio so cards are image-first with a consistent `16 / 9` presentation across breakpoints.
- Keep the template generator (`scripts/build_posts.py`) aligned with the new DOM structure so generated pages follow the same layout.

### Testing
- Served the site with `python -m http.server` and captured a visual verification screenshot using Playwright, which completed successfully and produced an artifact.
- No unit tests exist for the layout changes, and no automated test failures were reported.
- Verified files were staged and committed successfully via the repository `git` operations executed during the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ef9cc568832b90d6f90416507221)