### PR TITLE
Tweak hero card styling to match site cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -305,23 +305,22 @@ a:focus {
 .hero__card {
   background: var(--post-bg);
   border: 1px solid var(--border);
-  border-radius: 18px;
-  padding: 28px 30px;
-  box-shadow: 0 20px 30px rgba(76, 58, 32, 0.14);
+  border-radius: 16px;
+  padding: 22px 24px;
+  box-shadow: 0 12px 20px var(--shadow);
   display: grid;
   grid-template-columns: minmax(220px, 320px) 1fr;
   gap: 28px;
   align-items: center;
-  position: relative;
 }
 
 .hero__thumb {
   width: 100%;
-  border-radius: 14px;
-  border: 1px solid #eee5da;
+  border-radius: 10px;
+  border: 1px solid var(--border);
   object-fit: cover;
   aspect-ratio: 4 / 5;
-  box-shadow: 0 16px 28px rgba(58, 42, 20, 0.18);
+  box-shadow: 0 8px 18px var(--shadow);
 }
 
 .hero__content {
@@ -348,17 +347,15 @@ a:focus {
 }
 
 .hero__card .badge {
-  border: 1px solid #f1dcc4;
-  padding: 6px 14px;
+  border: 1px solid var(--border);
+  padding: 4px 10px;
   margin: 0;
   font-size: 0.7rem;
   letter-spacing: 0.2em;
-  background: #fff4e5;
-  color: var(--accent-strong);
-  border-radius: 999px;
-  position: absolute;
-  top: 18px;
-  right: 18px;
+  background: transparent;
+  color: var(--accent);
+  border-radius: 6px;
+  position: static;
 }
 
 .hero__card .badge::before,


### PR DESCRIPTION
### Motivation
- Restore the Index hero cards to the same visual language used by other site cards (for example `pages/contactanos.html`).
- Reduce heavy shadows, large radii and oversized padding that made the hero card diverge from the site style.
- Make thumbnail and badge treatment consistent with existing `post` card styling for a cleaner, unified look.

### Description
- Update `assets/css/style.css` to soften `.hero__card` by reducing `border-radius`, `padding`, shortening shadow offsets and switching the shadow to `var(--shadow)`, and remove `position: relative`.
- Adjust `.hero__thumb` to use `border-radius: 10px`, `border: 1px solid var(--border)`, and a smaller shadow matching `var(--shadow)`.
- Simplify `.hero__card .badge` to use `border: 1px solid var(--border)`, smaller padding, `background: transparent`, `color: var(--accent)`, `border-radius: 6px`, and `position: static`.

### Testing
- Started a local static server with `python -m http.server 8000`, which launched successfully.
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html` and produced a screenshot artifact `artifacts/index-hero-card.png`, and the script completed successfully.
- Committed the change with `git commit`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956fb3d4384832b8231c662a40a8ce8)