### PR TITLE
Align index cards with page panel styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,11 +303,10 @@ a:focus {
 }
 
 .hero__card {
-  background: var(--post-bg);
+  background: var(--panel);
   border: 1px solid var(--border);
-  border-radius: 18px;
-  padding: 28px 30px;
-  box-shadow: 0 20px 30px rgba(76, 58, 32, 0.14);
+  border-radius: 10px;
+  padding: 18px;
   display: grid;
   grid-template-columns: minmax(220px, 320px) 1fr;
   gap: 28px;
@@ -321,7 +320,6 @@ a:focus {
   border: 1px solid #eee5da;
   object-fit: cover;
   aspect-ratio: 4 / 5;
-  box-shadow: 0 16px 28px rgba(58, 42, 20, 0.18);
 }
 
 .hero__content {
@@ -384,12 +382,11 @@ a:focus {
 
 .post {
   border: 1px solid var(--border);
-  background: var(--post-bg);
-  border-radius: 16px;
-  padding: 22px 24px;
+  background: var(--panel);
+  border-radius: 10px;
+  padding: 18px;
   display: grid;
   gap: 12px;
-  box-shadow: 0 12px 20px rgba(59, 43, 22, 0.08);
 }
 
 .post--compact {


### PR DESCRIPTION
### Motivation
- Unify the visual style between the index and content pages by making cards use the same simpler panel look. 
- Remove heavy shadows and overly large radii/padding to match the page `side-panel` aesthetic. 
- Improve consistency and a cleaner, flatter UI across listings and individual pages.

### Description
- Updated `assets/css/style.css` to use `var(--panel)` as the background for the index hero card and stream posts. 
- Reduced corner radii and padding on `.hero__card` and `.post` to `10px` and `18px` respectively to match page panels. 
- Removed heavier `box-shadow` values from `.hero__card`, `.hero__thumb`, and `.post` for a flatter appearance. 
- All changes are contained in the single file `assets/css/style.css`.

### Testing
- Launched a local static server with `python -m http.server 8000` and ran a Playwright script to load `index.html` and capture a screenshot, which completed successfully. 
- No unit or integration tests were applicable since this is a pure CSS/UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695700b2bf40832ba7e56f8d29ba06ae)