### PR TITLE
Add 8 placeholder posts and generated HTML for layout work

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,182 @@
             </div>
           </div>
         </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-8.html">
+            <img class="post__thumb" src="assets/img/placeholder-8.jpg" alt="Imagen de relleno para el post 8" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-8.html">Placeholder Post 8</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-08</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-8.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-7.html">
+            <img class="post__thumb" src="assets/img/placeholder-7.jpg" alt="Imagen de relleno para el post 7" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-7.html">Placeholder Post 7</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-07</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-7.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-6.html">
+            <img class="post__thumb" src="assets/img/placeholder-6.jpg" alt="Imagen de relleno para el post 6" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-6.html">Placeholder Post 6</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-06</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-6.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-5.html">
+            <img class="post__thumb" src="assets/img/placeholder-5.jpg" alt="Imagen de relleno para el post 5" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-5.html">Placeholder Post 5</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-05</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-5.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-4.html">
+            <img class="post__thumb" src="assets/img/placeholder-4.jpg" alt="Imagen de relleno para el post 4" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-4.html">Placeholder Post 4</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-04</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-4.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-3.html">
+            <img class="post__thumb" src="assets/img/placeholder-3.jpg" alt="Imagen de relleno para el post 3" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-3.html">Placeholder Post 3</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-03</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-3.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-2.html">
+            <img class="post__thumb" src="assets/img/placeholder-2.jpg" alt="Imagen de relleno para el post 2" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-2.html">Placeholder Post 2</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-02</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-2.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
+          <a href="posts/placeholder-post-1.html">
+            <img class="post__thumb" src="assets/img/placeholder-1.jpg" alt="Imagen de relleno para el post 1" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/placeholder-post-1.html">Placeholder Post 1</a>
+            </h4>
+            <div class="post__meta">
+              <span>2025-01-01</span>
+              <span>Equipo ANXiNA · Diseño</span>
+            </div>
+            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+            <div class="post__tags">
+              <span>#placeholder</span>
+              <span>#maqueta</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/placeholder-post-1.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
         <!-- posts:end -->
       </div>
     </section>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 1</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 1</h1>
+        <div class="post__meta">
+          <span>2025-01-01 · 10:01</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-1.jpg" alt="Imagen de relleno para el post 1" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-1.txt
+++ b/posts/placeholder-post-1.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 1
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-01
+Time Created (HH:MM, 24h):
+10:01
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-1.jpg
+Featured Image Alt:
+Imagen de relleno para el post 1
+Slug (URL-friendly title):
+placeholder-post-1
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 2</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 2</h1>
+        <div class="post__meta">
+          <span>2025-01-02 · 10:02</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-2.jpg" alt="Imagen de relleno para el post 2" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-2.txt
+++ b/posts/placeholder-post-2.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 2
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-02
+Time Created (HH:MM, 24h):
+10:02
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-2.jpg
+Featured Image Alt:
+Imagen de relleno para el post 2
+Slug (URL-friendly title):
+placeholder-post-2
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 3</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 3</h1>
+        <div class="post__meta">
+          <span>2025-01-03 · 10:03</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-3.jpg" alt="Imagen de relleno para el post 3" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-3.txt
+++ b/posts/placeholder-post-3.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 3
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-03
+Time Created (HH:MM, 24h):
+10:03
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-3.jpg
+Featured Image Alt:
+Imagen de relleno para el post 3
+Slug (URL-friendly title):
+placeholder-post-3
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 4</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 4</h1>
+        <div class="post__meta">
+          <span>2025-01-04 · 10:04</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-4.jpg" alt="Imagen de relleno para el post 4" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-4.txt
+++ b/posts/placeholder-post-4.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 4
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-04
+Time Created (HH:MM, 24h):
+10:04
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-4.jpg
+Featured Image Alt:
+Imagen de relleno para el post 4
+Slug (URL-friendly title):
+placeholder-post-4
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 5</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 5</h1>
+        <div class="post__meta">
+          <span>2025-01-05 · 10:05</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-5.jpg" alt="Imagen de relleno para el post 5" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-5.txt
+++ b/posts/placeholder-post-5.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 5
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-05
+Time Created (HH:MM, 24h):
+10:05
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-5.jpg
+Featured Image Alt:
+Imagen de relleno para el post 5
+Slug (URL-friendly title):
+placeholder-post-5
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 6</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 6</h1>
+        <div class="post__meta">
+          <span>2025-01-06 · 10:06</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-6.jpg" alt="Imagen de relleno para el post 6" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-6.txt
+++ b/posts/placeholder-post-6.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 6
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-06
+Time Created (HH:MM, 24h):
+10:06
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-6.jpg
+Featured Image Alt:
+Imagen de relleno para el post 6
+Slug (URL-friendly title):
+placeholder-post-6
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 7</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 7</h1>
+        <div class="post__meta">
+          <span>2025-01-07 · 10:07</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-7.jpg" alt="Imagen de relleno para el post 7" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-7.txt
+++ b/posts/placeholder-post-7.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 7
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-07
+Time Created (HH:MM, 24h):
+10:07
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-7.jpg
+Featured Image Alt:
+Imagen de relleno para el post 7
+Slug (URL-friendly title):
+placeholder-post-7
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Placeholder Post 8</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="header-top">
+        <div class="central-clock" aria-live="polite">
+          <span class="central-clock__label">Central</span>
+          <time class="central-clock__time" data-central-time></time>
+        </div>
+        <div class="central-clock">
+          <span class="status-dot status-dot--ok" aria-hidden="true"></span>
+          <span class="central-clock__label">Conectado</span>
+        </div>
+      </div>
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Diseño</div>
+        <h1>Placeholder Post 8</h1>
+        <div class="post__meta">
+          <span>2025-01-08 · 10:08</span>
+          <span>Equipo ANXiNA</span>
+        </div>
+        <img src="../assets/img/placeholder-8.jpg" alt="Imagen de relleno para el post 8" style="width: 100%; border-radius: 12px;" />
+        <p>Este es un artículo de relleno para seguir diseñando la maqueta del sitio.</p>
+        <h2>Sección de ejemplo</h2>
+        <p>Texto breve para simular contenido real y probar el ritmo visual del diseño.</p>
+        <ul>
+          <li>Punto uno de relleno</li>
+          <li>Punto dos de relleno</li>
+          <li>Punto tres de relleno</li>
+        </ul>
+        <h3>Subtítulo</h3>
+        <p>Más texto de relleno para verificar espaciados, tamaños y jerarquía.</p>
+        <div class="post__tags">
+          <span>#placeholder</span>
+          <span>#maqueta</span>
+          <span>#diseno</span>
+          <span>#visual</span>
+        </div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/central-time.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/posts/placeholder-post-8.txt
+++ b/posts/placeholder-post-8.txt
@@ -1,0 +1,36 @@
+Title:
+Placeholder Post 8
+Body:
+Este es un artículo de relleno para seguir diseñando la maqueta del sitio.
+
+## Sección de ejemplo
+Texto breve para simular contenido real y probar el ritmo visual del diseño.
+
+- Punto uno de relleno
+- Punto dos de relleno
+- Punto tres de relleno
+
+### Subtítulo
+Más texto de relleno para verificar espaciados, tamaños y jerarquía.
+Tags (comma-separated):
+placeholder,maqueta,diseno,visual
+Date Created (YYYY-MM-DD):
+2025-01-08
+Time Created (HH:MM, 24h):
+10:08
+Author:
+Equipo ANXiNA
+Summary/Excerpt:
+Artículo de relleno para pruebas de layout y componentes visuales.
+Featured Image URL:
+placeholder-8.jpg
+Featured Image Alt:
+Imagen de relleno para el post 8
+Slug (URL-friendly title):
+placeholder-post-8
+Category:
+Diseño
+Status (draft/published):
+published
+Additional Notes:
+


### PR DESCRIPTION
### Motivation
- Provide multiple placeholder articles so the frontend and layout can be tested with more entries and thumbnails.
- Have realistic post source files to iterate on spacing, typography and component composition without real content.
- Ensure the site index shows these items so the post stream and compact post card layout can be verified.

### Description
- Add eight new post source files under `posts/placeholder-post-*.txt` containing metadata and filler content for each placeholder.
- Generate matching standalone HTML pages `posts/placeholder-post-*.html` with the site header, footer and formatted article body.
- Update `index.html` to include the eight placeholder posts in the posts stream so they appear on the home page.
- Commit the new files and generated HTML so the repository contains the placeholders for layout work.

### Testing
- Ran `python3 scripts/build_posts.py` which initially failed due to malformed placeholder expansion and parsing errors.
- Re-created the placeholder files with valid date/time strings and re-ran `python3 scripts/build_posts.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695710461d6c832bb104c440e201c033)