### PR TITLE
Enhance hero card styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -303,32 +303,53 @@ a:focus {
 }
 
 .hero__card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 245, 233, 0.9));
+  border: 1px solid rgba(213, 205, 196, 0.6);
+  border-radius: 20px;
+  padding: 22px;
   display: grid;
-  grid-template-columns: minmax(220px, 320px) 1fr;
+  grid-template-columns: minmax(220px, 340px) 1fr;
   gap: 28px;
   align-items: center;
   position: relative;
+  overflow: hidden;
+  box-shadow: 0 20px 45px rgba(55, 45, 30, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 189, 109, 0.16), transparent 55%);
+  pointer-events: none;
+}
+
+.hero__card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 60px rgba(55, 45, 30, 0.18);
 }
 
 .hero__thumb {
   width: 100%;
-  border-radius: 14px;
-  border: 1px solid #eee5da;
+  border-radius: 18px;
+  border: 1px solid rgba(213, 205, 196, 0.7);
   object-fit: cover;
   aspect-ratio: 4 / 5;
+  box-shadow: 0 12px 30px rgba(55, 45, 30, 0.16);
+  transition: transform 0.2s ease;
 }
 
 .hero__content {
   display: grid;
   gap: 12px;
+  position: relative;
+  z-index: 1;
 }
 
 .hero__card h2 {
   margin-top: 0;
+  font-size: clamp(1.4rem, 2vw, 1.9rem);
 }
 
 .badge {
@@ -346,17 +367,18 @@ a:focus {
 }
 
 .hero__card .badge {
-  border: 1px solid #f1dcc4;
-  padding: 6px 14px;
+  border: 1px solid rgba(255, 209, 162, 0.9);
+  padding: 6px 16px;
   margin: 0;
   font-size: 0.7rem;
   letter-spacing: 0.2em;
-  background: #fff4e5;
+  background: rgba(255, 243, 228, 0.95);
   color: var(--accent-strong);
   border-radius: 999px;
   position: absolute;
   top: 18px;
   right: 18px;
+  z-index: 1;
 }
 
 .hero__card .badge::before,


### PR DESCRIPTION
### Motivation

- Improve the visual appeal and perceived quality of the hero cards to create a more attractive site layout.
- Reinforce visual hierarchy and affordance so cards read better at a glance and feel more clickable.
- Add subtle motion and depth to make interactions feel responsive and modern.

### Description

- Update `assets/css/style.css` to use a soft diagonal gradient background, larger border-radius, increased padding, and stronger drop shadow for `.hero__card`.
- Add a decorative `::after` radial highlight, `overflow: hidden`, and hover lift via `transform` and shadow transitions for `.hero__card`.
- Refine `.hero__thumb` with increased border-radius, subtle image shadow and transitions, and elevate `.hero__content` with `z-index` and responsive `h2` sizing via `clamp()`.
- Tweak `.hero__card .badge` colors, padding, border, and stacking (`z-index`) for improved contrast and plating.

### Testing

- Launched a local server with `python -m http.server` and rendered `index.html` to visually inspect the change.
- Captured a screenshot using a Playwright script and saved it to `artifacts/hero-card.png`, and the capture completed successfully.
- No unit or integration tests were run since this is a static styling update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69574af07f4c832bbf28cffbeaf5a5e6)