### PR TITLE
Add hover lift and shadows to hero cards and posts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -283,12 +283,21 @@ a:focus {
   gap: 28px;
   align-items: center;
   position: relative;
+  box-shadow: 0 6px 16px rgba(31, 19, 8, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__card:hover,
+.hero__card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(31, 19, 8, 0.14);
 }
 
 .hero__thumb {
   width: 100%;
   border-radius: 14px;
-  border: 1px solid #eee5da;
+  border: 1px solid var(--border);
+  outline: 1px solid var(--border);
   object-fit: cover;
   aspect-ratio: 4 / 5;
 }
@@ -358,6 +367,14 @@ a:focus {
   padding: 18px;
   display: grid;
   gap: 12px;
+  box-shadow: 0 6px 16px rgba(31, 19, 8, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.post:hover,
+.post:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(31, 19, 8, 0.14);
 }
 
 .post--compact {
@@ -375,6 +392,7 @@ a:focus {
   width: 100%;
   border-radius: 10px;
   border: 1px solid var(--border);
+  outline: 1px solid var(--border);
   object-fit: cover;
   aspect-ratio: 16 / 9;
   box-shadow: 0 8px 18px var(--shadow);


### PR DESCRIPTION
### Motivation
- Improve visual affordance and consistency for card components by adding subtle elevation and hover/focus feedback.
- Replace the hardcoded thumbnail border color with the theme variable `var(--border)` for consistent theming.
- Make interactive regions like hero cards and posts feel more discoverable with a small lift on hover/focus.

### Description
- Updated `assets/css/style.css` to add `box-shadow` and `transition` to `.hero__card` and `.post`, and apply `transform: translateY(-2px)` with a stronger `box-shadow` on `:hover` and `:focus-within`.
- Replaced the `.hero__thumb` hardcoded `#eee5da` border with `border: 1px solid var(--border)` and added `outline: 1px solid var(--border)` to both `.hero__thumb` and `.post__thumb` for consistent framing.
- Kept existing `border-radius`, `object-fit`, and aspect ratios intact while adding the new visual treatments.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e243f098832b89866819310adabb)