### PR TITLE
Enhance button hover, active, and focus states

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -445,6 +445,23 @@ a:focus {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+}
+
+.button:hover {
+  background-color: color-mix(in srgb, var(--button-bg) 92%, #000);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.16);
+}
+
+.button:active {
+  transform: translateY(1px);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .post--compact .button {
@@ -453,10 +470,18 @@ a:focus {
   color: #4b4032;
 }
 
+.post--compact .button:hover {
+  background-color: color-mix(in srgb, #f4efe9 92%, #000);
+}
+
 .button.secondary {
   background: transparent;
   color: var(--button-secondary-text);
   border-color: var(--accent);
+}
+
+.button.secondary:hover {
+  background-color: color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .section-title {


### PR DESCRIPTION
### Motivation
- Improve tactile and keyboard feedback for `.button` elements by adding visual transitions and focus outlines.
- Provide subtle darkening on hover to make interactive elements more discoverable.
- Add active-state translation and shadow reduction to simulate physical button press.
- Ensure compact and secondary button variants receive matching hover treatments.

### Description
- Add `box-shadow` and `transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease` to the `.button` rule.
- Implement `.button:hover` to darken the background using `color-mix` and increase the shadow for emphasis.
- Implement `.button:active` with `transform: translateY(1px)` and a reduced shadow, and `.button:focus-visible` with an `outline` using `var(--accent)` and `outline-offset`.
- Add hover adjustments for `.post--compact .button` and `.button.secondary:hover` to keep variants consistent.

### Testing
- Started a local server with `python -m http.server 8000`, which served the site successfully.
- Ran a Playwright script that loaded the site, hovered the `.button` selector, and captured a screenshot to `artifacts/button-hover.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e38ef26c832b9467f6e9e25cd4a0)