### PR TITLE
Add translucent panel background, shadow and blur to .site-header

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -79,7 +79,11 @@ a:focus {
 
 .site-header {
   padding: 16px 0 20px;
+  background: var(--panel);
   border-bottom: 1px solid var(--border);
+  box-shadow: 0 6px 16px var(--shadow);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .brand {


### PR DESCRIPTION
### Motivation

- Visually separate the site header from page content and give it a subtle, more “tech” look.
- Use existing theme variables so light/dark contrast remains controlled via the design system.

### Description

- Updated `assets/css/style.css` `.site-header` to set `background: var(--panel)` for consistent theming.
- Added `box-shadow: 0 6px 16px var(--shadow)` to create a subtle elevation from the content below.
- Applied `backdrop-filter: blur(12px)` with `-webkit-backdrop-filter` for a translucent, blurred panel effect.

### Testing

- Served the site locally with `python -m http.server 8000` and captured a full-page screenshot using a Playwright script, which completed successfully.
- No unit or integration tests were executed for this purely visual/CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e4d848f4832b8c4747646a78b5c5)