### PR TITLE
Add baseline border to nav and adjust link padding

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -135,13 +135,14 @@ a:focus {
   letter-spacing: 0.08em;
   white-space: nowrap;
   overflow-x: auto;
-  padding-bottom: 2px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
 }
 
 .nav a {
   display: inline-flex;
   align-items: center;
-  padding-bottom: 6px;
+  padding-bottom: 4px;
   border-bottom: 2px solid transparent;
   color: var(--muted);
 }
@@ -168,7 +169,7 @@ a:focus {
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  padding-bottom: 6px;
+  padding-bottom: 4px;
   border-bottom: 2px solid transparent;
   color: inherit;
 }


### PR DESCRIPTION
### Motivation
- Give the main navigation a visible baseline so the active underline appears to float above it.
- Keep the `.active` highlight using `var(--accent)` unchanged while improving visual separation.

### Description
- Update `assets/css/style.css` to add `border-bottom: 1px solid var(--border)` to the `.nav` container and increase its `padding-bottom` to `6px`.
- Reduce `padding-bottom` on `.nav a` and `.nav-menu > summary` from `6px` to `4px` so the active underline sits above the new baseline.
- Leave the existing `.nav a.active` and related hover styles intact so the accent color and pseudo-element continue to indicate the active state.

### Testing
- Served the site with `python -m http.server 8000` and captured a full-page screenshot using Playwright, which completed successfully and produced `artifacts/nav-baseline.png`.
- No automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957e5d39958832bba5de04c4df512ec)