### PR TITLE
Refine post meta and tag chip styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -413,7 +413,7 @@ a:focus {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
-  font-size: 0.85rem;
+  font-size: 0.82rem;
   color: var(--muted);
 }
 
@@ -424,7 +424,9 @@ a:focus {
 }
 
 .post__tags span {
-  padding: 2px 8px;
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px 10px;
   border-radius: 999px;
   border: 1px solid var(--border);
   color: var(--accent);


### PR DESCRIPTION
### Motivation
- Improve visual hierarchy of post metadata by slightly reducing its font size and ensuring muted coloring. 
- Make post tags appear as distinct “chips” for better scannability and touch targets. 
- Use existing theme variables for borders and colors to keep styling consistent across light/dark modes. 

### Description
- Reduced `.post__meta` `font-size` from `0.85rem` to `0.82rem` while keeping `color: var(--muted)`. 
- Converted `.post__tags span` into an inline chip by adding `display: inline-flex`, `gap: 6px`, and increasing `padding` from `2px 8px` to `4px 10px`. 
- Kept `border-radius: 999px` and `border: 1px solid var(--border)` so chip borders follow the theme variable, and retained `color: var(--accent)` and `font-size: 0.8rem`. 

### Testing
- Launched a local server with `python -m http.server 8000` and captured a full-page screenshot via a Playwright script which completed successfully (`artifacts/post-tags.png`).
- No unit tests were applicable since this is a static CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957eb8081b8832ba2a7fa8ce3789492)