### PR TITLE
Simplify header navigation and move legal links to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a class="active" href="index.html" aria-current="page">Inicio</a>
+          <a href="#secciones">Secciones/Categorías</a>
           <a href="pages/contactanos.html">Contáctanos</a>
-          <a href="pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="pages/benefactores.html">Benefactores</a>
-          <a href="pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -61,7 +59,7 @@
       </div>
     </section>
 
-    <section class="container">
+    <section id="secciones" class="container">
       <h3 class="section-title">Stream de noticias</h3>
       <div id="stream" class="stream">
         <!-- posts:begin -->
@@ -292,8 +290,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Política de privacidad</a>
-          <a class="active" href="benefactores.html" aria-current="page">Benefactores</a>
-          <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -82,8 +80,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Política de privacidad</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -91,8 +89,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="contactanos.html">Contáctanos</a>
-          <a class="active" href="politica_de_privacidad.html" aria-current="page">Política de privacidad</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a href="terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -90,8 +88,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="contactanos.html">Contáctanos</a>
-          <a href="politica_de_privacidad.html">Política de privacidad</a>
-          <a href="benefactores.html">Benefactores</a>
-          <a class="active" href="terminos_de_servicio.html" aria-current="page">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -90,8 +88,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -103,8 +101,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -78,8 +76,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -20,10 +20,8 @@
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
         </nav>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
@@ -70,8 +68,9 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
-        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="../pages/terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>


### PR DESCRIPTION
### Motivation
- Reduce header clutter by exposing only editorial navigation (Inicio, Secciones/Categorías, Contáctanos) in the main site menu.  
- Ensure consistent header structure across `index.html`, files in `pages/` and `posts/`.  
- Place legal pages (Política de privacidad, Términos) in the site footer to centralize legal links.  
- Maintain accessibility by keeping `aria-current` correct for the active page and adding a `#secciones` anchor on the home page.

### Description
- Replaced the full header nav in `index.html`, `pages/*.html` and `posts/*.html` to only include `Inicio`, `Secciones/Categorías` (anchor) and `Contáctanos`.  
- Added `id="secciones"` to the home page section containing the stream so the `Secciones/Categorías` link targets a valid anchor.  
- Removed legal links from headers and added consistent footer copy linking to `pages/politica_de_privacidad.html` and `pages/terminos_de_servicio.html` across `index.html`, `pages/*.html` and `posts/*.html`.  
- Ensured `class="active"` and `aria-current="page"` remain on the proper active link (e.g. `index.html` and `pages/contactanos.html`).

### Testing
- Served the site locally with `python -m http.server 8000` to validate static pages were reachable and the changes rendered correctly (succeeded).  
- Captured a full-page screenshot of `http://127.0.0.1:8000/index.html` using Playwright which completed successfully and produced `artifacts/anxina-index.png`.  
- Ran repository searches (`rg`) to verify header and footer markup updates across `index.html`, `pages/` and `posts/` (succeeded).  
- No unit or integration test suite was run because these are static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957eeae292c832bb9226fba76233263)