### PR TITLE
Add category navigation block and static category pages

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -509,6 +509,48 @@ a:focus {
   background: linear-gradient(90deg, var(--accent), transparent);
 }
 
+.categories {
+  margin-bottom: 24px;
+  padding: 18px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: 0 10px 24px var(--shadow);
+}
+
+.categories__intro {
+  margin: 0 0 14px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.categories__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.category-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--callout-bg);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.category-pill:hover,
+.category-pill:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--callout-bg) 80%, var(--accent) 20%);
+}
+
 .material-symbols-outlined {
   font-size: 1.1em;
   line-height: 1;

--- a/index.html
+++ b/index.html
@@ -60,6 +60,17 @@
     </section>
 
     <section id="secciones" class="container">
+      <div class="categories">
+        <h3 class="section-title">Categorías</h3>
+        <p class="categories__intro">Explora las etiquetas destacadas en el stream y salta directo a cada tema.</p>
+        <div class="categories__list" aria-label="Categorías principales">
+          <a class="category-pill" href="pages/categoria-tecnologia.html">#tecnologia</a>
+          <a class="category-pill" href="pages/categoria-entretenimiento.html">#entretenimiento</a>
+          <a class="category-pill" href="pages/categoria-ia.html">#ia</a>
+          <a class="category-pill" href="pages/categoria-placeholder.html">#placeholder</a>
+          <a class="category-pill" href="pages/categoria-maqueta.html">#maqueta</a>
+        </div>
+      </div>
       <h3 class="section-title">Stream de noticias</h3>
       <div id="stream" class="stream">
         <!-- posts:begin -->

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Categoría Entretenimiento</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
+          <a href="contactanos.html">Contáctanos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <h1>Categoría: Entretenimiento</h1>
+      <p class="categories__intro">
+        Series, videojuegos y cultura pop con enfoque crítico. Aquí se agrupan las notas marcadas con
+        <strong>#entretenimiento</strong>.
+      </p>
+      <div class="callout">
+        ¿Quieres otra etiqueta? Regresa al <a href="../index.html#secciones">stream de noticias</a> y selecciona una.
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Categoría IA</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
+          <a href="contactanos.html">Contáctanos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <h1>Categoría: IA</h1>
+      <p class="categories__intro">
+        Lo último en inteligencia artificial, modelos, debates éticos y usos creativos. En esta página reunimos
+        el contenido con la etiqueta <strong>#ia</strong>.
+      </p>
+      <div class="callout">
+        Consulta otras etiquetas desde el <a href="../index.html#secciones">stream principal</a>.
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Categoría Maqueta</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
+          <a href="contactanos.html">Contáctanos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <h1>Categoría: Maqueta</h1>
+      <p class="categories__intro">
+        Espacio dedicado a bocetos, exploraciones visuales y pruebas editoriales. Aquí están las notas etiquetadas
+        con <strong>#maqueta</strong>.
+      </p>
+      <div class="callout">
+        Seguimos refinando el diseño del sitio: revisa el <a href="../index.html#secciones">stream principal</a>
+        para ver avances recientes.
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Categoría Placeholder</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
+          <a href="contactanos.html">Contáctanos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <h1>Categoría: Placeholder</h1>
+      <p class="categories__intro">
+        Contenido de prueba para validar layouts y componentes. Aquí quedan agrupadas las entradas etiquetadas como
+        <strong>#placeholder</strong>.
+      </p>
+      <div class="callout">
+        Cuando haya artículos finales, esta categoría servirá para pruebas internas y prototipos visuales.
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Categoría Tecnología</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../index.html#secciones">Secciones/Categorías</a>
+          <a href="contactanos.html">Contáctanos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <h1>Categoría: Tecnología</h1>
+      <p class="categories__intro">
+        Noticias, análisis y actualizaciones clave de hardware, software y cultura digital. Aquí reunimos las piezas
+        etiquetadas con <strong>#tecnologia</strong>.
+      </p>
+      <div class="callout">
+        ¿Buscas más temas? Vuelve al <a href="../index.html#secciones">stream de noticias</a> y explora otras etiquetas.
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Improve discoverability by surfacing post tags as a navigable "Categorías" block above the news stream. 
- Reuse existing `.post__tags` semantics to drive category navigation rather than adding new metadata.
- Provide fallback/static category pages when no dynamic category views exist so links resolve from the navigation.

### Description
- Inserted a `div.categories` block in `index.html` above the `#stream` with pill links to category pages. 
- Added CSS rules in `assets/css/style.css` for `.categories`, `.categories__list`, `.category-pill` and `.categories__intro` to make the section clear and scannable. 
- Created static category pages under `pages/` (`categoria-tecnologia.html`, `categoria-entretenimiento.html`, `categoria-ia.html`, `categoria-placeholder.html`, `categoria-maqueta.html`) with basic header/footer and explanatory copy. 

### Testing
- Started a local static server with `python -m http.server` and captured a visual smoke test using Playwright which produced a screenshot of `index.html#secciones` (succeeded). 
- Confirmed the new pages are reachable via their `pages/` paths during the visual check (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957effc961c832bb45a39a7181c9117)