### PR TITLE
Add client-side stream search filtering

### DIFF
--- a/assets/js/search-filter.js
+++ b/assets/js/search-filter.js
@@ -1,0 +1,62 @@
+const normalizeText = (value) =>
+  value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim();
+
+const updateStatus = (statusEl, query, matches, total) => {
+  if (!statusEl) {
+    return;
+  }
+
+  if (!query) {
+    statusEl.textContent = "";
+    return;
+  }
+
+  if (matches === 0) {
+    statusEl.textContent = `Sin resultados para “${query}”.`;
+    return;
+  }
+
+  statusEl.textContent = `${matches} de ${total} noticias coinciden con “${query}”.`;
+};
+
+const filterStream = () => {
+  const input = document.querySelector("#site-search");
+  if (!input) {
+    return;
+  }
+
+  const statusEl = document.querySelector("#search-status");
+  const posts = Array.from(document.querySelectorAll(".post"));
+  const searchableText = posts.map((post) =>
+    normalizeText(post.textContent || "")
+  );
+  const totalPosts = posts.length;
+
+  const handleInput = () => {
+    const query = normalizeText(input.value);
+    let matches = 0;
+
+    posts.forEach((post, index) => {
+      const isMatch = !query || searchableText[index].includes(query);
+      post.hidden = !isMatch;
+      if (isMatch) {
+        matches += 1;
+      }
+    });
+
+    updateStatus(statusEl, query, matches, totalPosts);
+  };
+
+  input.addEventListener("input", handleInput);
+  handleInput();
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", filterStream);
+} else {
+  filterStream();
+}

--- a/index.html
+++ b/index.html
@@ -23,10 +23,17 @@
           <a href="#secciones">Secciones/Categorías</a>
           <a href="pages/contactanos.html">Contáctanos</a>
         </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
@@ -72,6 +79,7 @@
         </div>
       </div>
       <h3 class="section-title">Stream de noticias</h3>
+      <p id="search-status" class="search-status" role="status" aria-live="polite"></p>
       <div id="stream" class="stream">
         <!-- posts:begin -->
         <article class="post post--compact">
@@ -309,5 +317,6 @@
   </footer>
   <script src="assets/js/theme-toggle.js"></script>
   <script src="assets/js/nav-menu.js"></script>
+  <script src="assets/js/search-filter.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Habilitar comportamiento para el `<input type="search">` del header que permita filtrar el stream de noticias en la página principal. 
- Proveer retroalimentación de estado accesible para búsquedas (por ejemplo “sin resultados”).
- Mantener la solución ligera y sin dependencias para poder funcionar en páginas estáticas.

### Description
- Convertí el control de búsqueda en el header a un `form` con el campo `input` identificado como `#site-search` y `name="q"`, y añadí `aria-controls="stream"` y `autocomplete="off"`.
- Añadí un elemento de estado `p#search-status` con `role="status"` y `aria-live="polite"` que muestra mensajes en función del resultado de la búsqueda.
- Añadí `assets/js/search-filter.js` que normaliza texto (`normalizeText`), filtra las entradas del DOM (`.post`) ocultando las que no coinciden, y actualiza el estado con `updateStatus`.
- Registré el script en `index.html` para inicializar el filtrado en `DOMContentLoaded` y ejecutar un filtrado inicial.

### Testing
- Se inició un servidor estático con `python -m http.server 8000` para probar la página localmente (arrancó correctamente, se interrumpió manualmente posteriormente).
- Se intentó un smoke test automático con Playwright para rellenar `#site-search` y capturar una captura de pantalla, pero la ejecución falló por timeout; el script no completó.
- No se agregaron pruebas unitarias automáticas al repositorio como parte de este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f11b31f0832b98c330d341886592)