### PR TITLE
Replace header nav with `<details>`-based nav menu and update styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -161,6 +161,11 @@ a:focus {
 
 .nav-menu {
   position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .nav-menu > summary {
@@ -200,13 +205,23 @@ a:focus {
 }
 
 .nav-menu__panel a {
+  display: inline-flex;
+  align-items: center;
   padding-bottom: 2px;
   border-bottom: 2px solid transparent;
+  color: var(--muted);
 }
 
 .nav-menu__panel a.active,
 .nav-menu__panel a:hover {
   border-color: var(--accent);
+  color: var(--accent);
+}
+
+.nav-menu__panel a.active::before {
+  content: "./";
+  margin-right: 4px;
+  color: var(--accent);
 }
 
 .sr-only {
@@ -647,6 +662,26 @@ a:focus {
   }
 
   .nav a {
+    width: 100%;
+    padding: 6px 0;
+  }
+
+  .nav-menu {
+    width: 100%;
+  }
+
+  .nav-menu > summary {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .nav-menu__panel {
+    position: static;
+    width: 100%;
+    margin-top: 8px;
+  }
+
+  .nav-menu__panel a {
     width: 100%;
     padding: 6px 0;
   }

--- a/index.html
+++ b/index.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a class="active" href="index.html" aria-current="page">Inicio</a>
-          <a href="#secciones">Secciones/Categorías</a>
-          <a href="pages/contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a class="active" href="index.html" aria-current="page">Inicio</a>
+            <a href="#secciones">Secciones/Categorías</a>
+            <a href="pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -18,11 +18,14 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="contactanos.html">Contáctanos</a>
-        </nav>
+        <details class="nav-menu">
+          <summary>Menú</summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />


### PR DESCRIPTION
### Motivation
- Modernize the header navigation to a compact, accessible toggleable menu using a native `<details class="nav-menu">` control.
- Preserve the existing navigation links and semantics while enabling programmatic closing via existing JS.
- Ensure the visual treatment of links inside the new panel matches the current nav style.
- Improve layout and behavior on small screens so the menu expands into the header flow.

### Description
- Replaced the inline header `nav` markup with a `details` element and a `nav` inside a `.nav-menu__panel` in `index.html` and all files under `pages/`.
- Kept all original links and `aria` attributes inside the new `nav-menu__panel` structure so link targets and `aria-current` are preserved.
- Updated `assets/css/style.css` to add `.nav-menu` and `.nav-menu__panel` styles, active link styling for panel links, and responsive rules under `@media (max-width: 720px)` to make the menu static and full-width on small screens.
- Left `assets/js/nav-menu.js` unchanged; it already contains logic to close open `.nav-menu` elements on link click and `Escape` and is compatible with the new markup.

### Testing
- Located and updated occurrences of header navigation using `rg` and `sed` commands to verify changes across `pages/` (succeeded).
- Started a local server with `python -m http.server` to serve the site for manual/automated rendering checks (server started successfully).
- Attempted an automated Playwright script to open the menu and capture a mobile screenshot, but the Playwright run timed out (failed to produce a screenshot).
- No unit or integration test suite was run against these static HTML/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f328f480832bb966e0b2c5915ed9)