### PR TITLE
Add in-article table of contents and section IDs for long posts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -432,6 +432,44 @@ a:focus {
   color: var(--muted);
 }
 
+.post__toc {
+  border: 1px solid var(--border);
+  background: var(--callout-bg);
+  border-radius: 10px;
+  padding: 16px;
+  display: grid;
+  gap: 8px;
+}
+
+.post__toc-title {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+
+.post__toc ol {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+}
+
+.post__toc ol ol {
+  margin-top: 6px;
+  padding-left: 18px;
+}
+
+.post__toc a {
+  color: var(--text);
+}
+
+.post__toc a:hover,
+.post__toc a:focus {
+  color: var(--accent-strong);
+}
+
 .post__tags {
   display: flex;
   gap: 10px;

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -46,44 +46,82 @@
           <span>2025-12-31 · 11:02</span>
           <span>Tepokato</span>
         </div>
+        <nav class="post__toc" aria-label="Contenido del artículo">
+          <h2 class="post__toc-title">Contenido</h2>
+          <ol>
+            <li>
+              <a href="#mejores-telefonos-calidad-precio">Los mejores teléfonos calidad-precio del año</a>
+              <ol>
+                <li><a href="#samsung-galaxy-a56-5g">Samsung Galaxy A56 5G</a></li>
+                <li><a href="#oneplus-13r-256">OnePlus 13R (256 GB)</a></li>
+                <li><a href="#google-pixel-9a-128">Google Pixel 9a (128 GB)</a></li>
+              </ol>
+            </li>
+            <li>
+              <a href="#mejores-series-ano">Las mejores series del año</a>
+              <ol>
+                <li><a href="#adolescence">Adolescence</a></li>
+                <li><a href="#pluribus">Pluribus</a></li>
+                <li><a href="#the-pitt">The Pitt</a></li>
+              </ol>
+            </li>
+            <li>
+              <a href="#mejores-peliculas-ano">Las mejores películas del año</a>
+              <ol>
+                <li><a href="#sinners">Sinners</a></li>
+                <li><a href="#one-battle-after-another">One Battle After Another</a></li>
+                <li><a href="#the-secret-agent">The Secret Agent</a></li>
+              </ol>
+            </li>
+            <li>
+              <a href="#tres-noticias-clave">Tres noticias clave del año</a>
+              <ol>
+                <li><a href="#ia-promesa-region">La IA deja de ser promesa y empieza a usarse en serio en la región</a></li>
+                <li><a href="#videojuegos-identidad-propia">El desarrollo de videojuegos latinoamericano gana identidad propia</a></li>
+                <li><a href="#ciencia-region-avances">Ciencia en la región: avances silenciosos, pero estratégicos</a></li>
+              </ol>
+            </li>
+            <li><a href="#cierre">Cierre</a></li>
+          </ol>
+        </nav>
         <img src="../assets/img/2025anxina.png" alt="Composición editorial sobre el año 2025 en tecnología y cultura" style="width: 100%; border-radius: 12px;" />
         <p>2025 no fue un año de grandes promesas cumplidas. Fue, más bien, un año donde muchas industrias mostraron sus límites: hardware cada vez más caro, entretenimiento saturado y tecnología que a veces parece avanzar más rápido que nuestra capacidad de adoptarla.</p>
         <p>Aun así, entre el ruido hubo cosas que sí valieron la pena. Esto es lo que realmente destacó para nosotros en ANXiNA.</p>
-        <h2>Los mejores teléfonos calidad-precio del año</h2>
+        <h2 id="mejores-telefonos-calidad-precio">Los mejores teléfonos calidad-precio del año</h2>
         <p>(Pensados para Latinoamérica)</p>
-        <h3>Samsung Galaxy A56 5G</h3>
+        <h3 id="samsung-galaxy-a56-5g">Samsung Galaxy A56 5G</h3>
         <p>Aunque personalmente creo que el segundo lugar es más interesante desde el punto de vista tecnológico —especialmente por la innovación en baterías que ya debería ser un estándar—, no se puede negar una cosa: lo que ofrece Samsung por lo que cuesta es difícil de igualar.</p>
         <p>El Galaxy A56 es un teléfono que entiende muy bien el contexto latinoamericano: buen rendimiento, pantalla sólida, batería confiable y una experiencia estable que no depende de trucos de marketing. Incluso frente al Pixel, que se mueve en un rango de precio similar, Samsung sigue teniendo una ventaja clara: Snapdragon todavía está un paso adelante en potencia real, algo que se nota sobre todo en videojuegos. Y seamos honestos: en Latinoamérica jugamos mucho en el celular.</p>
         <p>No es el más innovador, pero sí el más equilibrado. Y cuando el presupuesto importa, eso pesa más que cualquier promesa futurista.</p>
-        <h3>OnePlus 13R (256 GB)</h3>
+        <h3 id="oneplus-13r-256">OnePlus 13R (256 GB)</h3>
         <p>Aquí sí hablamos de innovación real. OnePlus fue de las primeras compañías en apostar fuerte por la nueva generación de baterías, una tecnología que cambia de forma tangible el uso diario: mejor autonomía, cargas más rápidas y una degradación mucho más lenta.</p>
         <p>Este no es solo un teléfono potente; es un teléfono que apuesta por el largo plazo, algo poco común en una industria obsesionada con ciclos de reemplazo rápidos. Si esta tecnología termina adoptándose de forma masiva —y todo apunta a que así será—, OnePlus podrá decir que estuvo ahí desde el inicio.</p>
-        <h3>Google Pixel 9a (128 GB)</h3>
+        <h3 id="google-pixel-9a-128">Google Pixel 9a (128 GB)</h3>
         <p>El Pixel 9a sigue siendo una opción muy sólida: cámara sobresaliente, software limpio y una experiencia bien cuidada. El problema vuelve a ser el mismo de siempre: el chip Tensor no termina de convencer. En potencia bruta y tareas exigentes se queda atrás, y eso se nota especialmente frente a Snapdragon.</p>
         <p>Es una lástima, porque si Google resolviera ese punto, este teléfono podría ser fácilmente el número uno de esta lista. Hoy sigue siendo recomendable, pero con reservas claras.</p>
-        <h2>Las mejores series del año</h2>
-        <h3>Adolescence</h3>
+        <h2 id="mejores-series-ano">Las mejores series del año</h2>
+        <h3 id="adolescence">Adolescence</h3>
         <p>No fue solo una serie popular; fue una conversación cultural. Adolescence abordó temas incómodos —juicio social, exposición digital, adolescencia— sin tratar al espectador como alguien que necesita explicaciones constantes. Una serie que incomoda, pero por buenas razones.</p>
-        <h3>Pluribus</h3>
+        <h3 id="pluribus">Pluribus</h3>
         <p>Ciencia ficción con intención. En un año saturado de historias sobre tecnología, Pluribus fue de las pocas que realmente se atrevió a cuestionar el impacto humano de lo digital, sin caer en el espectáculo vacío.</p>
-        <h3>The Pitt</h3>
+        <h3 id="the-pitt">The Pitt</h3>
         <p>Un drama médico que logró algo difícil: sentirse intenso sin ser exagerado. Ritmo, personajes bien construidos y una narrativa que sabe cuándo apretar y cuándo respirar.</p>
-        <h2>Las mejores películas del año</h2>
-        <h3>Sinners</h3>
+        <h2 id="mejores-peliculas-ano">Las mejores películas del año</h2>
+        <h3 id="sinners">Sinners</h3>
         <p>Una película que se negó a encajar en una sola categoría. Drama, horror y comentario social se mezclan en una obra que no busca comodidad, sino impacto. Cine que se siente necesario.</p>
-        <h3>One Battle After Another</h3>
+        <h3 id="one-battle-after-another">One Battle After Another</h3>
         <p>Ambiciosa, política y profundamente humana. Una película que demuestra que el cine todavía puede hablar de conflictos complejos sin simplificarlos para el consumo rápido.</p>
-        <h3>The Secret Agent</h3>
+        <h3 id="the-secret-agent">The Secret Agent</h3>
         <p>Cine latinoamericano que no pide permiso. Intensa, política y emocionalmente densa, es una de esas películas que no se olvidan al salir de la sala.</p>
-        <h2>Tres noticias clave del año</h2>
+        <h2 id="tres-noticias-clave">Tres noticias clave del año</h2>
         <p>Tecnología, ciencia y videojuegos con impacto en Latinoamérica</p>
-        <h3>1. La IA deja de ser promesa y empieza a usarse en serio en la región</h3>
+        <h3 id="ia-promesa-region">1. La IA deja de ser promesa y empieza a usarse en serio en la región</h3>
         <p>Durante 2025, varios países latinoamericanos comenzaron a integrar IA en procesos reales: desde optimización de servicios públicos hasta apoyo en diagnósticos médicos y educación. No resolvió problemas estructurales, pero marcó un cambio importante: la tecnología empezó a adaptarse a nuestras limitaciones, no al revés.</p>
-        <h3>2. El desarrollo de videojuegos latinoamericano gana identidad propia</h3>
+        <h3 id="videojuegos-identidad-propia">2. El desarrollo de videojuegos latinoamericano gana identidad propia</h3>
         <p>Este año quedó claro que Latinoamérica ya no solo consume videojuegos: los crea con voz propia. Estudios independientes empezaron a destacar no por imitar tendencias globales, sino por contar historias locales, con contextos y estéticas propias. Menos copia, más identidad.</p>
-        <h3>3. Ciencia en la región: avances silenciosos, pero estratégicos</h3>
+        <h3 id="ciencia-region-avances">3. Ciencia en la región: avances silenciosos, pero estratégicos</h3>
         <p>Mientras el foco mediático sigue en otros lugares, universidades y centros de investigación latinoamericanos lograron avances importantes en energía, biotecnología y salud, muchas veces con presupuestos limitados. No fueron titulares virales, pero sí pasos reales hacia autonomía científica.</p>
-        <h2>Cierre</h2>
+        <h2 id="cierre">Cierre</h2>
         <p>2025 no fue el año en que todo cambió.</p>
         <p>Fue el año en que quedó claro qué cosas ya no funcionan y cuáles todavía tienen sentido. Cuando el hype se apaga, lo que queda es lo que resiste el uso diario, la crítica y el tiempo. Eso —y no otra cosa— es lo que intentamos señalar aquí.</p>
         <div class="post__tags">

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -46,13 +46,22 @@
           <span>2025-12-29 · 21:28</span>
           <span>Tepokato</span>
         </div>
+        <nav class="post__toc" aria-label="Contenido del artículo">
+          <h2 class="post__toc-title">Contenido</h2>
+          <ol>
+            <li><a href="#mercado-segundo-plano">El mercado nos dejó en segundo plano</a></li>
+            <li><a href="#truco-optimizacion">El truco de la “Optimización”: Pan para hoy, hambre para mañana</a></li>
+            <li><a href="#obsolescencia-tercer-mundo">Obsolescencia para el tercer mundo</a></li>
+            <li><a href="#pregunta-que-duele">La pregunta que duele</a></li>
+          </ol>
+        </nav>
         <img src="../assets/img/ram-ia.png" alt="Ilustración de módulos de RAM junto a un chip con temática de inteligencia artificial" style="width: 100%; border-radius: 12px;" />
         <p>En Latinoamérica, cuando compramos tecnología, no solo compramos un aparato; compramos una herramienta que tiene que durar. Aquí no cambiamos de laptop cada año como quien cambia de camisa. Por eso, cuando escuchas a los grandes fabricantes decir que “8 GB de RAM son suficientes”, no te están dando un consejo técnico. Te están vendiendo una mentira cómoda para proteger sus ganancias.</p>
         <p>¿Lo peor? La culpa de que tu próxima computadora sea &quot;lenta por diseño&quot; la tiene una guerra en la que tú ni siquiera estás participando: la fiebre de la Inteligencia Artificial.</p>
-        <h2>1. El mercado nos dejó en segundo plano</h2>
+        <h2 id="mercado-segundo-plano">1. El mercado nos dejó en segundo plano</h2>
         <p>La realidad es cruda: la RAM que debería ir en tu teléfono o en tu PC está siendo secuestrada. Las empresas que fabrican los chips (Samsung, Micron, Hynix) están volcando toda su producción hacia los servidores de IA.</p>
         <p>¿Por qué venderte a ti 16 GB de RAM para tu laptop si pueden vendérsela a Nvidia o a Google por el triple de precio? Nosotros, los usuarios de a pie, nos hemos convertido en el &quot;segundo plato&quot; de la industria. Como la memoria está cara y escasa, las marcas prefieren convencernos de que no la necesitamos en lugar de pagar el costo de incluirla.</p>
-        <h2>2. El truco de la &quot;Optimización&quot;: Pan para hoy, hambre para mañana</h2>
+        <h2 id="truco-optimizacion">2. El truco de la &quot;Optimización&quot;: Pan para hoy, hambre para mañana</h2>
         <p>Seguro has escuchado el cuento de: &quot;Es que nuestro sistema gestiona la memoria de forma mágica&quot;.</p>
         <p>En el papel suena increíble. En la realidad de un usuario en México, Colombia o Argentina, es una trampa.</p>
         <ul>
@@ -61,10 +70,10 @@
           <li>En laptops: Abrir Chrome con tres pestañas y un Excel ya pone el equipo a sudar.</li>
         </ul>
         <p>Nos venden la &quot;optimización&quot; como si fuera un avance, cuando en realidad es como si te vendieran un auto con un tanque de gasolina de 5 litros diciéndote que &quot;el motor gasta poquito&quot;. Tarde o temprano, te vas a quedar tirado.</p>
-        <h2>3. Obsolescencia para el tercer mundo</h2>
+        <h2 id="obsolescencia-tercer-mundo">3. Obsolescencia para el tercer mundo</h2>
         <p>Para un usuario en EE.UU., que un equipo se ponga lento en dos años es una excusa para ir a la tienda por el modelo nuevo. Para nosotros, es una tragedia financiera.</p>
         <p>Al vendernos equipos con 8 GB de RAM en 2024/2025, las empresas están garantizando que tu inversión caduque rápido. Es obsolescencia programada por capacidad. No se te va a romper el procesador; simplemente te vas a quedar sin memoria para el software del futuro (que, irónicamente, vendrá lleno de funciones de IA que no pediste pero que consumen recursos).</p>
-        <h2>La pregunta que duele</h2>
+        <h2 id="pregunta-que-duele">La pregunta que duele</h2>
         <p>Si la tecnología supuestamente avanza para ser más eficiente, ¿por qué nos cuesta tanto mantener los estándares básicos de hace cinco años?</p>
         <p>La respuesta no está en los laboratorios de ingeniería, sino en las hojas de costos. Nos están pidiendo que nos conformemos con menos para que ellos puedan seguir alimentando a los monstruos de la IA sin sacrificar sus márgenes de ganancia.</p>
         <p>Comprar 8 GB de RAM hoy no es &quot;comprar lo justo&quot;, es comprar un problema para el próximo año.</p>


### PR DESCRIPTION
### Motivation
- Improve navigation in long-form posts by exposing a visible table-of-contents for readers.  
- Provide stable anchor targets for headings to allow deep-linking and keyboard navigation.  
- Keep visual style consistent with the site by adding a small TOC component in the main stylesheet.  

### Description
- Inserted a `nav.post__toc` block with an ordered list of anchors into `posts/anxina-paso-en-2025.html` and `posts/menos-ram-mas-discurso.html`.  
- Added unique `id` attributes to the corresponding `h2` and `h3` headings so each TOC link targets a real section.  
- Added CSS rules for `.post__toc`, `.post__toc-title`, and nested lists in `assets/css/style.css` to style the TOC and hover/focus states.  
- Preserved accessibility hints by including `aria-label` on the TOC navigation and using semantic lists for structure.  

### Testing
- Served the site locally with `python -m http.server` and used a Playwright script to load the updated post and capture a full-page screenshot, which rendered the TOC successfully.  
- Confirmed changes staged and recorded with a commit operation (commit completed without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f648e050832ba5a2acec59698f02)