### PR TITLE
Fix nav menu panel alignment on wide screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -191,9 +191,11 @@ a:focus {
 
 .nav-menu__panel {
   position: absolute;
-  right: 0;
+  left: 0;
+  right: auto;
   top: calc(100% + 10px);
   min-width: 190px;
+  max-width: min(240px, 90vw);
   padding: 12px;
   border-radius: 10px;
   background: var(--panel);
@@ -202,6 +204,7 @@ a:focus {
   display: grid;
   gap: 10px;
   z-index: 10;
+  box-sizing: border-box;
 }
 
 .nav-menu__panel a {


### PR DESCRIPTION
### Motivation
- The nav menu panel could appear partially off-screen on larger viewports when positioned to the right of the trigger.  
- The panel needed a viewport-aware width constraint to avoid overflowing the layout.  
- Using border-box prevents padding from increasing the effective width and causing overflow.  

### Description
- Change `assets/css/style.css` to position the menu panel from the left by setting `left: 0` and `right: auto`.  
- Add a max width constraint `max-width: min(240px, 90vw)` so the panel stays within the viewport.  
- Enable `box-sizing: border-box` on `.nav-menu__panel` to include padding in the element width calculation.  

### Testing
- Started a local server with `python -m http.server` to serve the site, which succeeded.  
- Attempted an automated Playwright script to open the page and capture a screenshot of the opened menu, but the Playwright run timed out and failed.  
- No unit tests were present or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695807a80004832b95c3da29e43132b3)