### PR TITLE
Raise header stacking to keep nav menu above hero card

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -84,6 +84,8 @@ a:focus {
   box-shadow: 0 6px 16px var(--shadow);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
+  position: relative;
+  z-index: 20;
 }
 
 .brand {


### PR DESCRIPTION
### Motivation
- The nav menu panel was rendering underneath the hero card badge (“En portada”), hiding menu items. 
- The header needs a higher stacking context so the menu overlay appears above page content. 
- This is a visual/layout fix to ensure the navigation is usable and visible across pages.

### Description
- Add `position: relative` and `z-index: 20` to the `.site-header` rule in `assets/css/style.css` to raise the header stacking. 
- The change ensures the `.nav-menu__panel` overlay sits above the hero card without altering layout flow.

### Testing
- A local server was started with `python -m http.server` to serve the site for visual verification. 
- A Playwright script was executed to capture a screenshot, but the Playwright run failed due to a browser crash/timeouts. 
- No other automated tests were run for this static CSS update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580c439488832bb75bb015894bdedf)