### PR TITLE
Add Material Symbols 'menu' icon to navigation toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a class="active" href="index.html" aria-current="page">Inicio</a>
             <a href="#secciones">Secciones/Categorías</a>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary>Menú</summary>
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>


### PR DESCRIPTION
### Motivation
- Improve the visual affordance of the site menu by adding the 3-line (hamburger) icon from Google Material Symbols. 
- Make the menu toggle presentation consistent across top-level pages for a uniform UI.

### Description
- Replace plain `<summary>Menú</summary>` with `<summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>` in `index.html` and top-level `pages/*.html` files.  
- Keep the existing Material Symbols stylesheet reference (`https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined`) and accessibility attributes like `aria-hidden="true"` on the icon.  
- The change is a static HTML update applied across the site's primary pages to preserve consistent navigation affordance.

### Testing
- Applied an automated replacement script to update all affected `index.html` and `pages/*.html` files and verified the replacements completed.  
- Started a local server with `python -m http.server 8000` and ran a Playwright script to load `index.html` and capture a screenshot, which produced `artifacts/menu-icon.png` successfully.  
- No unit tests were applicable for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580ea26240832b9f0834eed3d67e44)