### PR TITLE
Add styled 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · 404</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <details class="nav-menu">
+          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="index.html">Inicio</a>
+            <a href="index.html#secciones">Secciones/Categorías</a>
+            <a href="pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <h1>404 · Señal perdida</h1>
+      <p>
+        La página que buscas no está en nuestra frecuencia. Puede que el enlace haya cambiado, o que el artículo se
+        haya desconectado temporalmente.
+      </p>
+      <div class="hero__grid">
+        <div class="side-panel">
+          <h3>Retomar la transmisión</h3>
+          <p>Regresa al stream principal o explora las categorías destacadas para no perder el hilo.</p>
+          <div class="post__actions">
+            <a class="button" href="index.html">Volver al inicio</a>
+          </div>
+        </div>
+        <div class="side-panel">
+          <h3>Atajos útiles</h3>
+          <ul>
+            <li><span>#tecnologia</span><span><a href="pages/categoria-tecnologia.html">Ir ahora</a></span></li>
+            <li><span>#ia</span><span><a href="pages/categoria-ia.html">Ir ahora</a></span></li>
+            <li><span>#entretenimiento</span><span><a href="pages/categoria-entretenimiento.html">Ir ahora</a></span></li>
+          </ul>
+        </div>
+      </div>
+      <div class="callout" style="margin-top: 24px;">
+        Si llegaste aquí por un enlace roto, avísanos en <a href="pages/contactanos.html">Contáctanos</a> para
+        corregirlo.
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="pages/terminos_de_servicio.html">términos</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="assets/js/theme-toggle.js"></script>
+  <script src="assets/js/nav-menu.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a branded, site-consistent 404 page so users who hit a missing URL can quickly recover.  
- Match the existing layout and visual language by reusing the site header, footer and theme.  
- Offer direct shortcuts to important categories and the contact page to reduce user friction.  
- Improve UX for broken links and make it easier to report missing content.

### Description
- Add a new `404.html` file that mirrors the site header, footer, and main layout used in `index.html`.  
- Reuse site assets by linking `assets/css/style.css` and the behavior scripts `assets/js/theme-toggle.js` and `assets/js/nav-menu.js`.  
- Include navigation actions and category shortcuts linking to `index.html`, `index.html#secciones`, `pages/contactanos.html`, and category pages.  
- The file was added to the repository and committed as `404.html`.

### Testing
- Launched a local HTTP server with `python -m http.server 8000` and confirmed it started successfully.  
- Rendered `http://127.0.0.1:8000/404.html` with a Playwright script and captured a screenshot artifact, which completed successfully.  
- An initial Playwright run using a `file://` URL failed with `ERR_FILE_NOT_FOUND`, which was resolved by serving the site over HTTP.  
- No unit tests were applicable to this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69581113f1d0832bbba2df2d91bdc74e)