### PR TITLE
Generate Pebble Round 2 post and update homepage index

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,29 @@
       <div id="stream" class="stream">
         <!-- posts:begin -->
         <article class="post post--compact">
+          <a href="posts/pebble-round-2-volver-a-lo-esencial.html">
+            <img class="post__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
+          </a>
+          <div class="post__body">
+            <h4>
+              <a class="post__title-link" href="posts/pebble-round-2-volver-a-lo-esencial.html">Pebble Round 2: volver a lo esencial también es avanzar</a>
+            </h4>
+            <div class="post__meta">
+              <span>2026-01-02</span>
+              <span>Tepokato · Wearables</span>
+            </div>
+            <p>Un smartwatch que va a contracorriente.
+La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y software abierto, dejando de lado el exceso de funciones. Un recordatorio de que volver a lo esencial también puede ser innovación.</p>
+            <div class="post__tags">
+              <span>#pebble</span>
+              <span>#smartwatch</span>
+            </div>
+            <div class="post__actions">
+              <a class="button" href="posts/pebble-round-2-volver-a-lo-esencial.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>
+        <article class="post post--compact">
           <a href="posts/anxina-paso-en-2025.html">
             <img class="post__thumb" src="assets/img/2025anxina.png" alt="Composición editorial sobre el año 2025 en tecnología y cultura" />
           </a>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Pebble Round 2: volver a lo esencial también es avanzar</title>
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <div class="brand__badge">
+          <h1 class="brand__title">ANXiNA</h1>
+        </div>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+      </div>
+      <div class="header-meta">
+        <nav class="nav" aria-label="Navegación principal">
+          <a href="../index.html">Inicio</a>
+          <a href="../pages/contactanos.html">Contáctanos</a>
+          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
+          <a href="../pages/benefactores.html">Benefactores</a>
+          <a href="../pages/terminos_de_servicio.html">Términos</a>
+        </nav>
+        <label class="search" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input type="search" placeholder="buscar..." />
+        </label>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="page">
+    <div class="container">
+      <article class="post">
+        <div class="badge">Análisis · Wearables</div>
+        <h1>Pebble Round 2: volver a lo esencial también es avanzar</h1>
+        <div class="post__meta">
+          <span>2026-01-02 · 13:37</span>
+          <span>Tepokato</span>
+        </div>
+        <img src="../assets/img/pebe1.png" alt="pebe2.png" style="width: 100%; border-radius: 12px;" />
+        <p>Pebble vuelve a hacerlo a su manera. La nueva Pebble Round 2 recupera el diseño redondo y ultradelgado que marcó época en 2015, pero lo actualiza con la tecnología justa: una pantalla e-paper a color más grande y nítida, hasta 14 días de batería y un precio que hoy suena casi provocador: 199 dólares.</p>
+        <p>No hay sensor de ritmo cardíaco ni promesas de ser un reloj deportivo. Y ese es el punto. Pebble apuesta por un smartwatch que prioriza la experiencia diaria: notificaciones claras, control por botones que puedes usar sin mirar la muñeca, seguimiento básico de pasos y sueño, y una batería que no te obliga a vivir pendiente del cargador.</p>
+        <p>El reloj mide apenas 8.1 mm de grosor, monta una pantalla 1.3” (260×260) con retroiluminación, micrófonos dobles para dictado y respuestas por voz, y corre sobre Pebble OS en código abierto, lo que le da acceso a miles de apps y carátulas, además de nuevas integraciones con asistentes de IA.</p>
+        <p>Un breve recordatorio necesario</p>
+        <p>Pebble no “regresó” por nostalgia. Volvió porque Google liberó el código del sistema, permitiendo que la comunidad y el propio Eric Migicovsky retomaran el proyecto bajo una nueva etapa. Desde entonces, Pebble avanza con pasos pequeños pero firmes: hardware sencillo, software abierto y una comunidad que nunca se fue. Hoy el ecosistema está vivo, se actualiza, y ya incluso experimenta con IA en otros dispositivos como su anillo inteligente, funciones que llegarán más adelante a los relojes.</p>
+        <p>La Pebble Round 2 entra en preventa el 2 de enero y se espera que llegue en mayo. No intenta competir con Apple o Samsung. Compite contra el cansancio de relojes cada vez más complejos.</p>
+        <p>Y quizá ahí está su mayor acierto: recordarnos que a veces, hacer menos… es hacerlo mejor.</p>
+        <div class="post__tags">
+          <span>#pebble</span>
+          <span>#smartwatch</span>
+          <span>#wearables</span>
+        </div>
+
+        <section class="author-card">
+        <img class="author-card__avatar" src="../assets/img/author&#x27;s/tepokato.png" alt="Retrato de Tepokato (Jesus Ponce)" />
+          <div class="author-card__details">
+            <p class="author-card__name">Tepokato (Jesus Ponce)</p>
+            <p class="author-card__title">Ecomm customer service rep for H-E-B</p>
+            <p class="author-card__bio">Tech enthusiast, proud husband and father.</p>
+          </div>
+        </section>
+      </article>
+
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="../pages/contactanos.html">Contáctanos</a> o revisa nuestra
+        <a href="../pages/politica_de_privacidad.html">política de privacidad</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a new published post for the Pebble Round 2 article and surface it in the homepage stream.
- Convert the article content into a full HTML post and ensure it uses the site's templates and assets.

### Description
- Generated `posts/pebble-round-2-volver-a-lo-esencial.html` containing the full article HTML, author card, tags, and featured image.
- Updated `index.html` to include the new post in the stream listing with thumbnail, meta and tags.
- The changes were produced by running the content generation script `python3 scripts/build_posts.py`.

### Testing
- Executed `python3 scripts/build_posts.py` to generate the post and the homepage update, and the command completed successfully.
- No unit or integration test suite was run for this change (content generation only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69582adb2c70832b8fb3832aa09ad6bf)