### PR TITLE
Remove published post source files after build

### DIFF
--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -46,6 +46,7 @@ class Post:
     category: str
     status: str
     notes: str
+    source_path: Path
 
     @property
     def datetime(self) -> dt.datetime:
@@ -212,6 +213,7 @@ def parse_post(path: Path) -> Post:
         category=join_field("category"),
         status=join_field("status"),
         notes=join_field("notes"),
+        source_path=path,
     )
 
 
@@ -465,6 +467,8 @@ def main() -> None:
         html_output = render_post(post, related_posts, author)
         output_path = POSTS_DIR / f"{post.slug}.html"
         output_path.write_text(html_output, encoding="utf-8")
+        if post.status.lower() == "published" and post.source_path.exists():
+            post.source_path.unlink()
 
     stream_html = render_stream(published)
     update_index(stream_html)


### PR DESCRIPTION
### Motivation
- Prevent keeping `.txt` source files for posts after they are published to avoid leftover draft files in the repo.
- Record the original source path for each post so the build script can remove it safely after generating HTML.

### Description
- Add a `source_path: Path` field to the `Post` dataclass and populate it in `parse_post` with the input `path`.
- After generating each post HTML in `main`, delete the source file when `post.status.lower() == "published"` and the file exists by calling `post.source_path.unlink()`.
- Keep the deletion guarded by an existence check to avoid raising errors for missing files.

### Testing
- No automated tests were run for this change.
- The script was updated and committed locally; no CI or unit tests executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69582cdd08c0832bbefb8c8728df1b6b)