### PR TITLE
Auto-select latest post for portada

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,24 +48,26 @@
   <main id="contenido">
     <section class="hero">
       <div class="container hero__grid">
+        <!-- portada:begin -->
         <article class="hero__card">
-          <a href="posts/menos-ram-mas-discurso.html">
-            <img class="hero__thumb" src="assets/img/ram-ia.png" alt="Detalle de memoria y chips en miniatura" />
+          <a href="posts/pebble-round-2-volver-a-lo-esencial.html">
+            <img class="hero__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
           </a>
           <div class="hero__content">
             <div class="badge">En portada</div>
             <h2>
-              <a class="post__title-link" href="posts/menos-ram-mas-discurso.html">La redefinición de lo “suficiente”</a>
+              <a class="post__title-link" href="posts/pebble-round-2-volver-a-lo-esencial.html">Pebble Round 2: volver a lo esencial también es avanzar</a>
             </h2>
             <p>
-              Menos RAM para ti. Más memoria para la IA. Un análisis sobre cómo el discurso cambia cuando los costos
-              se disparan y la memoria se vuelve un recurso cada vez más disputado.
+              Un smartwatch que va a contracorriente.
+La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y software abierto, dejando de lado el exceso de funciones. Un recordatorio de que volver a lo esencial también puede ser innovación.
             </p>
             <div class="post__actions">
-              <a class="button" href="posts/menos-ram-mas-discurso.html">Leer artículo</a>
+              <a class="button" href="posts/pebble-round-2-volver-a-lo-esencial.html">Leer artículo</a>
             </div>
           </div>
         </article>
+        <!-- portada:end -->
       </div>
     </section>
 

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -158,6 +158,22 @@ STREAM_ITEM_TEMPLATE = """        <article class="post post--compact">
           </div>
         </article>"""
 
+HERO_TEMPLATE = """        <article class="hero__card">
+          <a href="posts/{slug}.html">
+            <img class="hero__thumb" src="{image}" alt="{alt}" />
+          </a>
+          <div class="hero__content">
+            <div class="badge">En portada</div>
+            <h2>
+              <a class="post__title-link" href="posts/{slug}.html">{title}</a>
+            </h2>
+            <p>{summary}</p>
+            <div class="post__actions">
+              <a class="button" href="posts/{slug}.html">Leer artículo</a>
+            </div>
+          </div>
+        </article>"""
+
 
 RELATED_ITEM_TEMPLATE = """          <article class="post post--compact">
             <a href="{slug}.html">
@@ -415,6 +431,16 @@ def render_stream(posts: list[Post]) -> str:
     return "\n".join(items)
 
 
+def render_portada(post: Post) -> str:
+    return HERO_TEMPLATE.format(
+        image=html.escape(normalize_index_image(post.featured_image)),
+        alt=html.escape(post.featured_image_alt),
+        title=html.escape(post.title),
+        summary=html.escape(post.summary),
+        slug=html.escape(post.slug),
+    )
+
+
 def select_related(post: Post, candidates: list[Post], limit: int = 3) -> list[Post]:
     if not post.tags:
         return []
@@ -437,10 +463,12 @@ def select_related(post: Post, candidates: list[Post], limit: int = 3) -> list[P
     return [candidate for _, _, candidate in scored[:limit]]
 
 
-def update_index(stream_html: str) -> None:
+def update_index(stream_html: str, portada_html: str | None = None) -> None:
     content = INDEX_PATH.read_text(encoding="utf-8")
     start_marker = "<!-- posts:begin -->"
     end_marker = "<!-- posts:end -->"
+    portada_start = "<!-- portada:begin -->"
+    portada_end = "<!-- portada:end -->"
 
     if start_marker not in content or end_marker not in content:
         raise RuntimeError("Missing stream markers in index.html")
@@ -449,6 +477,14 @@ def update_index(stream_html: str) -> None:
     _, after = rest.split(end_marker, 1)
 
     updated = f"{before}{start_marker}\n{stream_html}\n        {end_marker}{after}"
+
+    if portada_html is not None:
+        if portada_start not in updated or portada_end not in updated:
+            raise RuntimeError("Missing portada markers in index.html")
+        before_portada, rest_portada = updated.split(portada_start, 1)
+        _, after_portada = rest_portada.split(portada_end, 1)
+        updated = f"{before_portada}{portada_start}\n{portada_html}\n        {portada_end}{after_portada}"
+
     INDEX_PATH.write_text(updated, encoding="utf-8")
 
 
@@ -467,7 +503,8 @@ def main() -> None:
         output_path.write_text(html_output, encoding="utf-8")
 
     stream_html = render_stream(published)
-    update_index(stream_html)
+    portada_html = render_portada(published[0]) if published else None
+    update_index(stream_html, portada_html)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Make the homepage hero (“portada”) be driven by content so it always shows the most recent published post.
- Provide a programmatic marker in `index.html` so the build script can replace the portada block automatically.
- Keep the existing stream rendering while adding a separate hero template so the stream and portada are managed independently.

### Description
- Add a `HERO_TEMPLATE` and a new `render_portada` function to render a portada hero from a `Post`.
- Extend `update_index` to accept an optional `portada_html` and replace content between `<!-- portada:begin -->` and `<!-- portada:end -->` markers.
- Update `main` to compute `portada_html` from the latest published post (`published[0]`) and pass it to `update_index`.
- Mark the portada block in `index.html` with `<!-- portada:begin -->`/`<!-- portada:end -->` and update the initial hero content to point at the current latest post.

### Testing
- Started a local server with `python -m http.server` and loaded `index.html` to validate the page could be served successfully.
- Used Playwright to open `http://127.0.0.1:8000/index.html` and capture a screenshot saved to `artifacts/portada-latest.png`, and the screenshot was produced successfully.
- No automated unit tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69582c3052dc832badd21d27c11dbdff)