### PR TITLE
Replace Material Symbols with Bootstrap Icons

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -662,7 +662,7 @@ a:focus {
   background: color-mix(in srgb, var(--callout-bg) 80%, var(--accent) 20%);
 }
 
-.material-symbols-outlined {
+.bi {
   font-size: 1.1em;
   line-height: 1;
   vertical-align: text-bottom;

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA</title>
   <link rel="stylesheet" href="assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a class="active" href="index.html" aria-current="page">Inicio</a>
             <a href="#secciones">Secciones/Categorías</a>
@@ -38,7 +38,7 @@
           />
         </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Benefactores</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Entretenimiento</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría IA</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Maqueta</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Placeholder</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Tecnología</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Contáctanos</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>
@@ -51,21 +51,21 @@
           <ul>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+                <i class="bi bi-envelope" aria-hidden="true"></i>
                 Correo editorial
               </span>
               <span>editorial@anxina.com</span>
             </li>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">satellite_alt</span>
+                <i class="bi bi-broadcast" aria-hidden="true"></i>
                 Pistas de última hora
               </span>
               <span>tips@anxina.com</span>
             </li>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">mic</span>
+                <i class="bi bi-mic" aria-hidden="true"></i>
                 Invitaciones
               </span>
               <span>podcast@anxina.com</span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Política de privacidad</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>
@@ -51,21 +51,21 @@
           <ul>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">mail</span>
+                <i class="bi bi-envelope" aria-hidden="true"></i>
                 Boletín
               </span>
               <span>Correo y preferencias</span>
             </li>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">query_stats</span>
+                <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
                 Métricas
               </span>
               <span>Visitas agregadas</span>
             </li>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">chat</span>
+                <i class="bi bi-chat-dots" aria-hidden="true"></i>
                 Mensajes
               </span>
               <span>Contenido que nos envías</span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Términos de servicio</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
@@ -19,7 +19,7 @@
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>
@@ -51,21 +51,21 @@
           <ul>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">sticky_note_2</span>
+                <i class="bi bi-sticky" aria-hidden="true"></i>
                 Citas
               </span>
               <span>Permite compartir con crédito</span>
             </li>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">link</span>
+                <i class="bi bi-link-45deg" aria-hidden="true"></i>
                 Enlaces
               </span>
               <span>Siempre con fuente visible</span>
             </li>
             <li>
               <span class="icon-text">
-                <span class="material-symbols-outlined" aria-hidden="true">block</span>
+                <i class="bi bi-slash-circle" aria-hidden="true"></i>
                 Reventa
               </span>
               <span>No autorizada</span>


### PR DESCRIPTION
### Motivation
- Remove dependency on Google Material Symbols and standardize on Bootstrap Icons for the static site.
- Update icon markup so icons render correctly with the new icon set across pages and components.

### Description
- Swap the Material Symbols stylesheet link for the Bootstrap Icons CDN in `index.html` and all pages under `pages/`.
- Replace inline Material Symbols spans like `<span class="material-symbols-outlined">…</span>` with Bootstrap icon markup like `<i class="bi bi-..." aria-hidden="true"></i>` across multiple HTML files.
- Update CSS to target the Bootstrap icon class by renaming `.material-symbols-outlined` to `.bi` in `assets/css/style.css`.
- Changes touch the site header, theme toggle, and various side-panel icons across the site.

### Testing
- Launched a local static server with `python -m http.server` and confirmed the site served successfully.
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html` and saved a full-page screenshot successfully.
- Used `rg` (ripgrep) to check for leftover `Material+Symbols` / `material-symbols-outlined` references and found none.
- All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69583555b378832b9113a808dc716cbd)