### PR TITLE
Update theme toggle to use Bootstrap sun/moon icons

### DIFF
--- a/404.html
+++ b/404.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -11,7 +11,9 @@
     toggle.setAttribute('aria-pressed', theme === 'light');
     toggle.setAttribute('aria-label', theme === 'light' ? 'Activar tema oscuro' : 'Activar tema claro');
     if (icon) {
-      icon.textContent = theme === 'light' ? 'light_mode' : 'dark_mode';
+      icon.classList.add('bi');
+      icon.classList.toggle('bi-sun-fill', theme === 'light');
+      icon.classList.toggle('bi-moon-fill', theme !== 'light');
     }
   };
 

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -31,7 +31,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-stars" aria-hidden="true"></i>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -30,7 +30,7 @@
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -95,7 +95,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
           <input type="search" placeholder="buscar..." />
         </label>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <span class="theme-toggle__icon material-symbols-outlined" aria-hidden="true">dark_mode</span>
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>
       </div>


### PR DESCRIPTION
### Motivation
- Standardize the theme toggle to use Bootstrap Icons instead of Material Symbols and remove visible text content, keeping only an icon for clarity.
- Ensure the visual state reflects the current theme using appropriate `bi-sun-fill` for light and `bi-moon-fill` for dark.
- Align generated post templates with the new markup so pages produced by `scripts/build_posts.py` match the runtime behavior.

### Description
- Replace theme toggle markup in multiple pages and the post template with `<i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>` instead of text-based Material Symbols. 
- Update `assets/js/theme-toggle.js` so `applyTheme` toggles the Bootstrap icon classes (`bi-sun-fill` / `bi-moon-fill`) and ensures the `bi` class is present. 
- Update `scripts/build_posts.py` template to emit the new icon markup for generated posts. 
- Updated many static HTML files under `pages/`, `posts/`, and `404.html` to use the new markup.

### Testing
- Launched a local server with `python -m http.server 8000` and ran a Playwright script to load `index.html` and capture a screenshot, which completed successfully. 
- Verified file changes with searches (`rg`) to confirm the `theme-toggle__icon` elements were updated across pages. 
- No unit tests were added or run for this visual/static change. 
- Changes were committed to the branch after verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69583863231c832b8f55c782be1c94a1)