### PR TITLE
Add Bootstrap 5.3.8 CDN CSS and JS links to site pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA</title>
   <link rel="stylesheet" href="assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -346,5 +347,6 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
   <script src="assets/js/theme-toggle.js"></script>
   <script src="assets/js/nav-menu.js"></script>
   <script src="assets/js/search-filter.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Benefactores</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -91,5 +92,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Entretenimiento</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -62,5 +63,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría IA</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -62,5 +63,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Maqueta</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -63,5 +64,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Placeholder</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -62,5 +63,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Tecnología</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -62,5 +63,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Contáctanos</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -100,5 +101,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Política de privacidad</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -99,5 +100,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Términos de servicio</title>
   <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -99,5 +100,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Bring the site onto Bootstrap `5.3.8` via CDN so Bootstrap CSS and scripts are available across static pages.
- Ensure interactive Bootstrap components load by adding the bundle JS before the closing `</body>`.
- Keep the existing `bootstrap-icons@1.11.3` inclusion unchanged.

### Description
- Inserted `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" />` immediately after `assets/css/style.css` in `index.html` and all `pages/*.html` files.
- Appended `<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>` immediately before the `</body>` tag in the same files.
- Files modified: `index.html` and `pages/benefactores.html`, `pages/categoria-entretenimiento.html`, `pages/categoria-ia.html`, `pages/categoria-maqueta.html`, `pages/categoria-placeholder.html`, `pages/categoria-tecnologia.html`, `pages/contactanos.html`, `pages/politica_de_privacidad.html`, and `pages/terminos_de_servicio.html`.

### Testing
- No automated tests were executed for these static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695846bd5abc832ba48b9d58d97fe237)