### PR TITLE
Align post headers with index

### DIFF
--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -19,17 +19,25 @@
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input
+            id="site-search"
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            aria-controls="stream"
+            autocomplete="off"
+          />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>


### PR DESCRIPTION
### Motivation
- Post pages used a different header structure than the index, causing inconsistent navigation, search and theme controls across the site.
- The goal is to make the header in every post match the index layout for consistent UX and accessibility.

### Description
- Replaced the header in all post HTML files to match the index header: a `details`-based `nav-menu`, the `form`-based search with `id="site-search"` and the same `theme-toggle` button.
- Simplified post navigation links to mirror the index (links to `../index.html`, `../index.html#secciones`, and `../pages/contactanos.html`).
- Fixed header spacing/formatting issues (ensured newline after the skip link) across posts.
- Changes applied to 11 files in `posts/` via a header-replace script.

### Testing
- Ran the header-replacement script which reported `updated 11` files successfully.
- Served the site with `python -m http.server 8000` and captured a screenshot of an updated post using a Playwright script which completed and produced `artifacts/post-header.png`.
- Committed the updated files; the repository shows the updated posts staged and committed successfully.
- No unit tests were added since this is a static HTML change and visual verification was performed automatically by the screenshot step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69584edad7e8832ba1d167562914695a)