### PR TITLE
Add SEO, Open Graph, Twitter and JSON-LD metadata to homepage and posts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,28 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA</title>
+  <meta name="description" content="Noticias de tecnología, ciencia y videojuegos con señal clara." />
+  <link rel="canonical" href="index.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA" />
+  <meta property="og:description" content="Noticias de tecnología, ciencia y videojuegos con señal clara." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="index.html" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="ANXiNA" />
+  <meta name="twitter:description" content="Noticias de tecnología, ciencia y videojuegos con señal clara." />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "ANXiNA",
+      "url": "index.html",
+      "description": "Noticias de tecnología, ciencia y videojuegos con señal clara."
+    }
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · ANXiNA paso en 2025</title>
+  <meta name="description" content="2025 no fue un año de grandes promesas cumplidas. Fue, más bien, un año donde muchas industrias mostraron sus límites: hardware cada vez más caro, entretenimiento saturado y tecnología que a veces parece avanzar más rápido que nuestra capacidad de adoptarla." />
+  <link rel="canonical" href="anxina-paso-en-2025.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA paso en 2025" />
+  <meta property="og:description" content="2025 no fue un año de grandes promesas cumplidas. Fue, más bien, un año donde muchas industrias mostraron sus límites: hardware cada vez más caro, entretenimiento saturado y tecnología que a veces parece avanzar más rápido que nuestra capacidad de adoptarla." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="anxina-paso-en-2025.html" />
+  <meta property="og:image" content="../assets/img/2025anxina.png" />
+  <meta property="og:image:alt" content="Composición editorial sobre el año 2025 en tecnología y cultura" />
+  <meta property="article:published_time" content="2025-12-31T11:02:00" />
+  <meta property="article:modified_time" content="2025-12-31T11:02:00" />
+  <meta property="article:author" content="Tepokato" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="ANXiNA paso en 2025" />
+  <meta name="twitter:description" content="2025 no fue un año de grandes promesas cumplidas. Fue, más bien, un año donde muchas industrias mostraron sus límites: hardware cada vez más caro, entretenimiento saturado y tecnología que a veces parece avanzar más rápido que nuestra capacidad de adoptarla." />
+  <meta name="twitter:image" content="../assets/img/2025anxina.png" />
+  <meta name="twitter:image:alt" content="Composición editorial sobre el año 2025 en tecnología y cultura" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "anxina-paso-en-2025.html"
+  },
+  "headline": "ANXiNA paso en 2025",
+  "description": "2025 no fue un año de grandes promesas cumplidas. Fue, más bien, un año donde muchas industrias mostraron sus límites: hardware cada vez más caro, entretenimiento saturado y tecnología que a veces parece avanzar más rápido que nuestra capacidad de adoptarla.",
+  "image": [
+    "../assets/img/2025anxina.png"
+  ],
+  "datePublished": "2025-12-31T11:02:00",
+  "dateModified": "2025-12-31T11:02:00",
+  "author": {
+    "@type": "Person",
+    "name": "Tepokato"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · La redefinición de lo “suficiente”</title>
+  <meta name="description" content="En Latinoamérica, cuando compramos tecnología, no solo compramos un aparato; compramos una herramienta que tiene que durar. Aquí no cambiamos de laptop cada año como quien cambia de camisa. Por eso, cuando escuchas a los grandes fabricantes decir que “8 GB de RAM son suficientes”, no te están dando un consejo técnico. Te están vendiendo una mentira cómoda para proteger sus ganancias." />
+  <link rel="canonical" href="menos-ram-mas-discurso.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="La redefinición de lo “suficiente”" />
+  <meta property="og:description" content="En Latinoamérica, cuando compramos tecnología, no solo compramos un aparato; compramos una herramienta que tiene que durar. Aquí no cambiamos de laptop cada año como quien cambia de camisa. Por eso, cuando escuchas a los grandes fabricantes decir que “8 GB de RAM son suficientes”, no te están dando un consejo técnico. Te están vendiendo una mentira cómoda para proteger sus ganancias." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="menos-ram-mas-discurso.html" />
+  <meta property="og:image" content="../assets/img/ram-ia.png" />
+  <meta property="og:image:alt" content="Ilustración de módulos de RAM junto a un chip con temática de inteligencia artificial" />
+  <meta property="article:published_time" content="2025-12-29T21:28:00" />
+  <meta property="article:modified_time" content="2025-12-29T21:28:00" />
+  <meta property="article:author" content="Tepokato" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="La redefinición de lo “suficiente”" />
+  <meta name="twitter:description" content="En Latinoamérica, cuando compramos tecnología, no solo compramos un aparato; compramos una herramienta que tiene que durar. Aquí no cambiamos de laptop cada año como quien cambia de camisa. Por eso, cuando escuchas a los grandes fabricantes decir que “8 GB de RAM son suficientes”, no te están dando un consejo técnico. Te están vendiendo una mentira cómoda para proteger sus ganancias." />
+  <meta name="twitter:image" content="../assets/img/ram-ia.png" />
+  <meta name="twitter:image:alt" content="Ilustración de módulos de RAM junto a un chip con temática de inteligencia artificial" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "menos-ram-mas-discurso.html"
+  },
+  "headline": "La redefinición de lo “suficiente”",
+  "description": "En Latinoamérica, cuando compramos tecnología, no solo compramos un aparato; compramos una herramienta que tiene que durar. Aquí no cambiamos de laptop cada año como quien cambia de camisa. Por eso, cuando escuchas a los grandes fabricantes decir que “8 GB de RAM son suficientes”, no te están dando un consejo técnico. Te están vendiendo una mentira cómoda para proteger sus ganancias.",
+  "image": [
+    "../assets/img/ram-ia.png"
+  ],
+  "datePublished": "2025-12-29T21:28:00",
+  "dateModified": "2025-12-29T21:28:00",
+  "author": {
+    "@type": "Person",
+    "name": "Tepokato"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Pebble Round 2: volver a lo esencial también es avanzar</title>
+  <meta name="description" content="Pebble vuelve a hacerlo a su manera. La nueva Pebble Round 2 recupera el diseño redondo y ultradelgado que marcó época en 2015, pero lo actualiza con la tecnología justa: una pantalla e-paper a color más grande y nítida, hasta 14 días de batería y un precio que hoy suena casi provocador: 199 dólares." />
+  <link rel="canonical" href="pebble-round-2-volver-a-lo-esencial.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Pebble Round 2: volver a lo esencial también es avanzar" />
+  <meta property="og:description" content="Pebble vuelve a hacerlo a su manera. La nueva Pebble Round 2 recupera el diseño redondo y ultradelgado que marcó época en 2015, pero lo actualiza con la tecnología justa: una pantalla e-paper a color más grande y nítida, hasta 14 días de batería y un precio que hoy suena casi provocador: 199 dólares." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="pebble-round-2-volver-a-lo-esencial.html" />
+  <meta property="og:image" content="../assets/img/pebe1.png" />
+  <meta property="og:image:alt" content="pebe2.png" />
+  <meta property="article:published_time" content="2026-01-02T13:37:00" />
+  <meta property="article:modified_time" content="2026-01-02T13:37:00" />
+  <meta property="article:author" content="Tepokato" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Pebble Round 2: volver a lo esencial también es avanzar" />
+  <meta name="twitter:description" content="Pebble vuelve a hacerlo a su manera. La nueva Pebble Round 2 recupera el diseño redondo y ultradelgado que marcó época en 2015, pero lo actualiza con la tecnología justa: una pantalla e-paper a color más grande y nítida, hasta 14 días de batería y un precio que hoy suena casi provocador: 199 dólares." />
+  <meta name="twitter:image" content="../assets/img/pebe1.png" />
+  <meta name="twitter:image:alt" content="pebe2.png" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "pebble-round-2-volver-a-lo-esencial.html"
+  },
+  "headline": "Pebble Round 2: volver a lo esencial también es avanzar",
+  "description": "Pebble vuelve a hacerlo a su manera. La nueva Pebble Round 2 recupera el diseño redondo y ultradelgado que marcó época en 2015, pero lo actualiza con la tecnología justa: una pantalla e-paper a color más grande y nítida, hasta 14 días de batería y un precio que hoy suena casi provocador: 199 dólares.",
+  "image": [
+    "../assets/img/pebe1.png"
+  ],
+  "datePublished": "2026-01-02T13:37:00",
+  "dateModified": "2026-01-02T13:37:00",
+  "author": {
+    "@type": "Person",
+    "name": "Tepokato"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 1</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-1.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 1" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-1.html" />
+  <meta property="og:image" content="../assets/img/placeholder-1.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 1" />
+  <meta property="article:published_time" content="2025-01-01T10:01:00" />
+  <meta property="article:modified_time" content="2025-01-01T10:01:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 1" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-1.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 1" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-1.html"
+  },
+  "headline": "Placeholder Post 1",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-1.jpg"
+  ],
+  "datePublished": "2025-01-01T10:01:00",
+  "dateModified": "2025-01-01T10:01:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 2</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-2.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 2" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-2.html" />
+  <meta property="og:image" content="../assets/img/placeholder-2.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 2" />
+  <meta property="article:published_time" content="2025-01-02T10:02:00" />
+  <meta property="article:modified_time" content="2025-01-02T10:02:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 2" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-2.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 2" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-2.html"
+  },
+  "headline": "Placeholder Post 2",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-2.jpg"
+  ],
+  "datePublished": "2025-01-02T10:02:00",
+  "dateModified": "2025-01-02T10:02:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 3</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-3.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 3" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-3.html" />
+  <meta property="og:image" content="../assets/img/placeholder-3.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 3" />
+  <meta property="article:published_time" content="2025-01-03T10:03:00" />
+  <meta property="article:modified_time" content="2025-01-03T10:03:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 3" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-3.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 3" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-3.html"
+  },
+  "headline": "Placeholder Post 3",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-3.jpg"
+  ],
+  "datePublished": "2025-01-03T10:03:00",
+  "dateModified": "2025-01-03T10:03:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 4</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-4.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 4" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-4.html" />
+  <meta property="og:image" content="../assets/img/placeholder-4.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 4" />
+  <meta property="article:published_time" content="2025-01-04T10:04:00" />
+  <meta property="article:modified_time" content="2025-01-04T10:04:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 4" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-4.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 4" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-4.html"
+  },
+  "headline": "Placeholder Post 4",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-4.jpg"
+  ],
+  "datePublished": "2025-01-04T10:04:00",
+  "dateModified": "2025-01-04T10:04:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 5</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-5.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 5" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-5.html" />
+  <meta property="og:image" content="../assets/img/placeholder-5.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 5" />
+  <meta property="article:published_time" content="2025-01-05T10:05:00" />
+  <meta property="article:modified_time" content="2025-01-05T10:05:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 5" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-5.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 5" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-5.html"
+  },
+  "headline": "Placeholder Post 5",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-5.jpg"
+  ],
+  "datePublished": "2025-01-05T10:05:00",
+  "dateModified": "2025-01-05T10:05:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 6</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-6.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 6" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-6.html" />
+  <meta property="og:image" content="../assets/img/placeholder-6.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 6" />
+  <meta property="article:published_time" content="2025-01-06T10:06:00" />
+  <meta property="article:modified_time" content="2025-01-06T10:06:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 6" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-6.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 6" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-6.html"
+  },
+  "headline": "Placeholder Post 6",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-6.jpg"
+  ],
+  "datePublished": "2025-01-06T10:06:00",
+  "dateModified": "2025-01-06T10:06:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 7</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-7.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 7" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-7.html" />
+  <meta property="og:image" content="../assets/img/placeholder-7.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 7" />
+  <meta property="article:published_time" content="2025-01-07T10:07:00" />
+  <meta property="article:modified_time" content="2025-01-07T10:07:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 7" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-7.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 7" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-7.html"
+  },
+  "headline": "Placeholder Post 7",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-7.jpg"
+  ],
+  "datePublished": "2025-01-07T10:07:00",
+  "dateModified": "2025-01-07T10:07:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -4,9 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Placeholder Post 8</title>
+  <meta name="description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <link rel="canonical" href="placeholder-post-8.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="Placeholder Post 8" />
+  <meta property="og:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="placeholder-post-8.html" />
+  <meta property="og:image" content="../assets/img/placeholder-8.jpg" />
+  <meta property="og:image:alt" content="Imagen de relleno para el post 8" />
+  <meta property="article:published_time" content="2025-01-08T10:08:00" />
+  <meta property="article:modified_time" content="2025-01-08T10:08:00" />
+  <meta property="article:author" content="Equipo ANXiNA" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Placeholder Post 8" />
+  <meta name="twitter:description" content="Este es un artículo de relleno para seguir diseñando la maqueta del sitio." />
+  <meta name="twitter:image" content="../assets/img/placeholder-8.jpg" />
+  <meta name="twitter:image:alt" content="Imagen de relleno para el post 8" />
+  <meta name="theme-color" content="#f6efe6" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "NewsArticle",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "placeholder-post-8.html"
+  },
+  "headline": "Placeholder Post 8",
+  "description": "Este es un artículo de relleno para seguir diseñando la maqueta del sitio.",
+  "image": [
+    "../assets/img/placeholder-8.jpg"
+  ],
+  "datePublished": "2025-01-08T10:08:00",
+  "dateModified": "2025-01-08T10:08:00",
+  "author": {
+    "@type": "Person",
+    "name": "Equipo ANXiNA"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "ANXiNA"
+  }
+}
+  </script>
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>


### PR DESCRIPTION
### Motivation
- Ensure pages include standard SEO and social-sharing metadata for better discovery and previews.
- Provide News-specific structured data so article pages can be understood by search engines and news surfaces.
- Add canonical and theme-color hints without requiring any new images.

### Description
- Added Open Graph, Twitter Card, `description`, `canonical` and `theme-color` tags to `index.html` and the post template in `scripts/build_posts.py`.
- Implemented `build_post_json_ld` to generate `NewsArticle` JSON-LD and injected it into the post HTML output via the updated `HTML_TEMPLATE`.
- Populated OG/Twitter fields and canonical URLs when rendering posts and wrote updated `posts/*.html` files to include the new metadata and JSON-LD block.

### Testing
- Ran an automated Python script that parsed existing post HTML, generated the meta tags and JSON-LD, and wrote updated files, and the script completed without errors.
- Verified that updated files were written (`posts/*.html` and `index.html`) and that the injected JSON-LD blocks are syntactically valid JSON.
- No additional test suite was present or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695858f0d130832ba990a69fe8774171)