### PR TITLE
Enhance mobile header navigation styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -780,6 +780,12 @@ a:focus {
 
   .header-meta {
     gap: 12px;
+    width: 100%;
+    padding: 16px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: var(--post-bg);
+    box-shadow: 0 10px 24px var(--shadow);
   }
 
   .nav {
@@ -800,17 +806,29 @@ a:focus {
   .nav-menu > summary {
     width: 100%;
     justify-content: space-between;
+    padding: 10px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: var(--callout-bg);
   }
 
   .nav-menu__panel {
     position: static;
     width: 100%;
     margin-top: 8px;
+    border-radius: 12px;
+    padding: 14px;
   }
 
   .nav-menu__panel a {
     width: 100%;
-    padding: 6px 0;
+    padding: 8px 10px;
+    border-radius: 8px;
+  }
+
+  .nav-menu__panel a:hover,
+  .nav-menu__panel a:focus-visible {
+    background: var(--callout-bg);
   }
 
   .header-meta {


### PR DESCRIPTION
### Motivation
- Improve the small-screen visual hierarchy so the header/meta area reads as a clear, tappable block.  
- Make navigation on narrow viewports more finger-friendly by increasing hit targets and adding visual feedback.  
- Improve discovery of the menu by styling the menu summary and its panel to stand out against content.  

### Description
- Updated `assets/css/style.css` to give the mobile `.header-meta` a card-like container with `padding`, `border-radius`, `border`, `background`, and `box-shadow`.  
- Restyled the mobile `.nav-menu > summary` to add `padding`, `border-radius`, `border`, and `background` for a larger tap target.  
- Adjusted `.nav-menu__panel` to use `border-radius` and `padding` and made links (`.nav-menu__panel a`) full-width with increased `padding` and `border-radius`.  
- Added hover/focus background states for `.nav-menu__panel a` to provide clear feedback on interaction.  

### Testing
- Launched a local static server with `python -m http.server 8000` and captured a mobile viewport screenshot using Playwright to verify layout changes.  
- A screenshot was produced at `artifacts/mobile-nav.png` for visual inspection and the mobile header/menu appearance was validated.  
- No automated unit tests were run for these purely styling changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958668adec4832ba2a2c1cc607dde1e)