### PR TITLE
Link site logo to homepage across pages, posts, and generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,10 +32,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -12,10 +12,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -56,10 +56,12 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -99,10 +99,12 @@ HTML_TEMPLATE = """<!DOCTYPE html>
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
-        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">


### PR DESCRIPTION
### Motivation
- Make the site brand/logo a clickable link back to the homepage for consistent navigation across index, pages, and posts.
- Ensure generated posts include the same behavior by updating the post generator template.
- Improve user experience by providing an obvious way to return to the homepage from any content page.

### Description
- Wrap the header `.brand` markup in an anchor `class="brand__link"` with the correct relative `href` in `index.html`, files under `pages/`, and files under `posts/`.
- Update `scripts/build_posts.py` `HTML_TEMPLATE` to emit the same `<a class="brand__link" href="../index.html">…</a>` so future generated posts include the linked logo.
- Applied the change across 21 files (index, `pages/*`, `posts/*`) and updated the repository.

### Testing
- Ran the Python update script which reported `Updated 21 files` to apply the change successfully.
- Verified the new `brand__link` occurrences with `rg` and confirmed the updated files returned the expected matches.
- Launched a local HTTP server and captured a screenshot with Playwright to visually confirm the linked logo on the homepage, which completed without errors.
- No unit tests exist for this static markup change, so no unit test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695874d913dc832b92bf19539efecd2e)