### PR TITLE
Add search results page and wire header search forms to it

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -756,10 +756,256 @@ a:focus {
   color: var(--text);
 }
 
+.search-page {
+  padding: 32px 0 60px;
+}
+
+.search-page__hero {
+  margin-bottom: 24px;
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  background: var(--post-bg);
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 24px var(--shadow);
+}
+
+.search-bar input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 1rem;
+  outline: none;
+}
+
+.search-bar__icon {
+  color: var(--muted);
+  font-size: 1.15rem;
+}
+
+.search-bar__clear {
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.search-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.filter-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 18px;
+  box-shadow: 0 10px 24px var(--shadow);
+}
+
+.filter-panel__title {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--muted);
+}
+
+.filter-group {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--border);
+}
+
+.filter-group__toggle {
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0;
+  cursor: pointer;
+}
+
+.filter-options {
+  margin-top: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.filter-option {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.filter-option input {
+  accent-color: var(--accent);
+}
+
+.search-results__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.search-results__label {
+  margin: 0 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.search-results__title {
+  margin: 0 0 6px;
+  font-size: 1.6rem;
+}
+
+.search-results__count {
+  margin: 0;
+  color: var(--muted);
+}
+
+.search-results__controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.filter-chip {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.filter-chip.is-active {
+  background: var(--accent);
+  border-color: var(--accent-strong);
+  color: #2a1f05;
+}
+
+.search-results__list {
+  display: grid;
+  gap: 18px;
+}
+
+.result-card {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 18px;
+  padding: 18px;
+  border-radius: 16px;
+  background: var(--post-bg);
+  border: 1px solid var(--border);
+  box-shadow: 0 10px 24px var(--shadow);
+}
+
+.result-card__thumb {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  object-fit: cover;
+  aspect-ratio: 4 / 3;
+}
+
+.result-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.result-card__badge {
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent);
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+}
+
+.result-card__badge--tech {
+  border-color: #7e66ff;
+  color: #7e66ff;
+  background: color-mix(in srgb, #7e66ff 18%, transparent);
+}
+
+.result-card__badge--science {
+  border-color: #2fbf84;
+  color: #2fbf84;
+  background: color-mix(in srgb, #2fbf84 18%, transparent);
+}
+
+.result-card__badge--review {
+  border-color: #f2c14c;
+  color: #f2c14c;
+  background: color-mix(in srgb, #f2c14c 18%, transparent);
+}
+
+.result-card__title {
+  margin: 8px 0;
+  font-size: 1.15rem;
+}
+
+.result-card__content p {
+  margin: 0 0 12px;
+  color: var(--muted);
+}
+
+.result-card__footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.search-results__actions {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+}
+
 .search__prompt {
   color: var(--accent);
   font-weight: 700;
   letter-spacing: 0.08em;
+}
+
+@media (max-width: 960px) {
+  .search-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .result-card {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {

--- a/assets/js/search-page.js
+++ b/assets/js/search-page.js
@@ -1,0 +1,36 @@
+const getQuery = () => {
+  const params = new URLSearchParams(window.location.search);
+  return (params.get("q") || "").trim();
+};
+
+const updateSearchPage = () => {
+  const query = getQuery();
+  const term = query || "todo";
+  const termEl = document.querySelector("[data-search-term]");
+  const countEl = document.querySelector("[data-results-count]");
+  const inputs = document.querySelectorAll('input[name="q"]');
+  const results = document.querySelectorAll(".result-card");
+
+  inputs.forEach((input) => {
+    input.value = query;
+  });
+
+  if (termEl) {
+    termEl.textContent = term;
+  }
+
+  if (countEl) {
+    const count = results.length;
+    countEl.textContent = `Se encontraron ${count} artículos.`;
+  }
+
+  document.title = query
+    ? `ANXiNA · Resultados para “${query}”`
+    : "ANXiNA · Resultados de búsqueda";
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", updateSearchPage);
+} else {
+  updateSearchPage();
+}

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
             <a href="pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input
             id="site-search"

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -28,10 +28,10 @@
             <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -28,10 +28,10 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <label class="search" aria-label="Buscar en ANXiNA">
+        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+          <input type="search" name="q" placeholder="buscar..." />
+        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/search.html
+++ b/search.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ANXiNA · Resultados de búsqueda</title>
+  <meta name="description" content="Resultados de búsqueda en ANXiNA." />
+  <link rel="canonical" href="search.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA · Resultados de búsqueda" />
+  <meta property="og:description" content="Encuentra noticias, reseñas y reportajes en ANXiNA." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="search.html" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="ANXiNA · Resultados de búsqueda" />
+  <meta name="twitter:description" content="Encuentra noticias, reseñas y reportajes en ANXiNA." />
+  <meta name="theme-color" content="#0c0a06" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
+</head>
+<body>
+  <a class="skip-link" href="#contenido">Saltar al contenido</a>
+  <header class="site-header">
+    <div class="container">
+      <div class="brand">
+        <a class="brand__link" href="index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
+        </a>
+      </div>
+      <div class="header-meta">
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="index.html">Inicio</a>
+            <a href="index.html#secciones">Secciones/Categorías</a>
+            <a href="pages/contactanos.html">Contáctanos</a>
+          </nav>
+        </details>
+        <form class="search" role="search" action="search.html" method="get" aria-label="Buscar en ANXiNA">
+          <span class="search__prompt" aria-hidden="true">&gt;_</span>
+          <input
+            type="search"
+            name="q"
+            placeholder="buscar..."
+            autocomplete="off"
+          />
+        </form>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <main id="contenido" class="search-page">
+    <div class="container">
+      <section class="search-page__hero" aria-label="Búsqueda principal">
+        <form class="search-bar" action="search.html" method="get">
+          <i class="bi bi-search search-bar__icon" aria-hidden="true"></i>
+          <input
+            type="search"
+            name="q"
+            placeholder="Busca artículos, autores o temas"
+            aria-label="Buscar en ANXiNA"
+            autocomplete="off"
+          />
+          <span class="search-bar__clear" aria-hidden="true">
+            <i class="bi bi-x-lg"></i>
+          </span>
+        </form>
+      </section>
+
+      <div class="search-layout">
+        <aside class="filter-panel" aria-label="Filtrar resultados">
+          <p class="filter-panel__title">Filtrar resultados</p>
+
+          <div class="filter-group">
+            <button class="filter-group__toggle" type="button" aria-expanded="true">
+              Categoría
+              <i class="bi bi-chevron-down" aria-hidden="true"></i>
+            </button>
+            <div class="filter-options">
+              <label class="filter-option">
+                <input type="checkbox" checked />
+                Videojuegos
+              </label>
+              <label class="filter-option">
+                <input type="checkbox" />
+                Tecnología
+              </label>
+              <label class="filter-option">
+                <input type="checkbox" />
+                Ciencia
+              </label>
+            </div>
+          </div>
+
+          <div class="filter-group">
+            <button class="filter-group__toggle" type="button" aria-expanded="false">
+              Tipo de contenido
+              <i class="bi bi-chevron-down" aria-hidden="true"></i>
+            </button>
+          </div>
+
+          <div class="filter-group">
+            <button class="filter-group__toggle" type="button" aria-expanded="false">
+              Rango de fechas
+              <i class="bi bi-chevron-down" aria-hidden="true"></i>
+            </button>
+          </div>
+        </aside>
+
+        <section class="search-results" aria-live="polite">
+          <header class="search-results__header">
+            <div>
+              <p class="search-results__label">Resultados para</p>
+              <h1 class="search-results__title">“<span data-search-term>Indie Development in Brazil</span>”</h1>
+              <p class="search-results__count" data-results-count>Se encontraron 4 artículos.</p>
+            </div>
+            <div class="search-results__controls" role="group" aria-label="Ordenar resultados">
+              <button class="filter-chip is-active" type="button">
+                Relevancia
+                <i class="bi bi-sliders" aria-hidden="true"></i>
+              </button>
+              <button class="filter-chip" type="button">Más recientes</button>
+            </div>
+          </header>
+
+          <div class="search-results__list">
+            <article class="result-card">
+              <img class="result-card__thumb" src="assets/img/pebe1.png" alt="Pantalla con código en una laptop" />
+              <div class="result-card__content">
+                <div class="result-card__meta">
+                  <span class="result-card__badge">Videojuegos</span>
+                  <span>Hace 2 días</span>
+                </div>
+                <h2 class="result-card__title">El estado del desarrollo indie en Brasil: panorama 2024</h2>
+                <p>
+                  Un vistazo a estudios locales como AQUiRIS y Long Hat House mientras navegan el mercado global y mantienen
+                  identidad cultural. Conversamos con 15 desarrolladores en São Paulo.
+                </p>
+                <div class="result-card__footer">
+                  <span>Juan Perez</span>
+                  <span>·</span>
+                  <span>8 min de lectura</span>
+                </div>
+              </div>
+            </article>
+
+            <article class="result-card">
+              <img class="result-card__thumb" src="assets/img/2025anxina.png" alt="Composición editorial con dispositivos y gráficos" />
+              <div class="result-card__content">
+                <div class="result-card__meta">
+                  <span class="result-card__badge result-card__badge--tech">Tech</span>
+                  <span>Oct 12, 2023</span>
+                </div>
+                <h2 class="result-card__title">Hardware Giants mira a Latinoamérica como nuevo hub de manufactura</h2>
+                <p>
+                  Con el cambio en cadenas globales, Brasil y México emergen como polos clave para ensamblaje de
+                  semiconductores. ¿Qué significa para el ecosistema indie?
+                </p>
+                <div class="result-card__footer">
+                  <span>Maria Costa</span>
+                  <span>·</span>
+                  <span>5 min de lectura</span>
+                </div>
+              </div>
+            </article>
+
+            <article class="result-card">
+              <img class="result-card__thumb" src="assets/img/ram-ia.png" alt="Ilustración de módulos de RAM en contexto de IA" />
+              <div class="result-card__content">
+                <div class="result-card__meta">
+                  <span class="result-card__badge result-card__badge--science">Ciencia</span>
+                  <span>Sep 28, 2023</span>
+                </div>
+                <h2 class="result-card__title">Triángulo del litio: innovación vs extracción en Argentina</h2>
+                <p>
+                  Mientras la extracción se acelera, científicos en Buenos Aires desarrollan métodos sostenibles que podrían
+                  proteger ecosistemas locales.
+                </p>
+                <div class="result-card__footer">
+                  <span>Alejandro Rossi</span>
+                  <span>·</span>
+                  <span>12 min de lectura</span>
+                </div>
+              </div>
+            </article>
+
+            <article class="result-card">
+              <img class="result-card__thumb" src="assets/img/pebe2.png" alt="Control retro de videojuegos" />
+              <div class="result-card__content">
+                <div class="result-card__meta">
+                  <span class="result-card__badge result-card__badge--review">Review</span>
+                  <span>Aug 15, 2023</span>
+                </div>
+                <h2 class="result-card__title">Blasphemous 2: una obra maestra del pixel art y el castigo</h2>
+                <p>
+                  The Game Kitchen regresa con una secuela que refina cada mecánica. Exploramos su conexión con iconografía
+                  religiosa y su resonancia en LATAM.
+                </p>
+                <div class="result-card__footer">
+                  <span>Sofia Mendez</span>
+                  <span>·</span>
+                  <span>6 min de lectura</span>
+                </div>
+              </div>
+            </article>
+          </div>
+
+          <div class="search-results__actions">
+            <button class="button secondary" type="button">
+              Cargar más artículos
+              <i class="bi bi-chevron-down" aria-hidden="true"></i>
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="pages/contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="pages/politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="pages/terminos_de_servicio.html">términos</a>.
+      </p>
+    </div>
+  </footer>
+  <script src="assets/js/theme-toggle.js"></script>
+  <script src="assets/js/nav-menu.js"></script>
+  <script src="assets/js/search-page.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated search results page so pressing Enter in the header search navigates to a results UI.
- Present a consistent results layout with filters and result cards matching the requested mock.
- Hydrate the page from the `q` query parameter so the search term and result count update automatically.
- Ensure all header search controls submit to the new `search.html` endpoint.

### Description
- Add a new `search.html` file with a search results layout, placeholder result cards and a filter panel.
- Add `assets/js/search-page.js` that reads the `q` URL parameter, fills inputs and updates the page title and results count.
- Update `index.html` and all `pages/*.html` header search controls to use a `<form action="search.html" method="get">` and include `name="q"` on the search input.
- Extend `assets/css/style.css` with styles for `.search-page`, the search bar, filter panel, result cards and responsive behavior, and fix a few image references used by the results examples.

### Testing
- Started a local static server with `python -m http.server 8000` and loaded the search page successfully.
- Ran a Playwright script that navigated to `http://127.0.0.1:8000/search.html?q=Indie%20Development%20in%20Brazil` and captured a screenshot, which completed successfully.
- Verified the new `assets/js/search-page.js` file and `search.html` were created and committed via `git commit`.
- No automated unit tests exist for this static HTML/CSS/JS change; manual/automated visual check via Playwright was used instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69589021ff5c832ba244eb888a2bea69)