### PR TITLE
Limit logo link to badge only

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -16,8 +16,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -60,8 +60,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -103,8 +103,8 @@ HTML_TEMPLATE = """<!DOCTYPE html>
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <nav class="nav" aria-label="Navegación principal">

--- a/search.html
+++ b/search.html
@@ -27,8 +27,8 @@
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
-          <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
         </a>
+        <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">


### PR DESCRIPTION
### Motivation
- The brand link currently wraps both the visual badge and the subtitle which makes the subtitle clickable instead of only the badge. 
- Restricting the link to the badge improves semantics and prevents accidental navigation from the subtitle. 
- Keep the site header consistent across pages and generated posts by aligning templates to the new structure.

### Description
- Moved the `<p class="brand__subtitle">` element outside the `<a class="brand__link">` so only the badge is linked in `index.html`, `search.html`, `pages/*.html`, and `posts/*.html`.
- Updated the `HTML_TEMPLATE` in `scripts/build_posts.py` to emit the same brand markup for generated posts.
- The update touched multiple static HTML files and the build template (23 files updated in this change).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695894b56008832ba744fb10826be0cb)