### PR TITLE
Adopt warm editorial theme

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,39 +1,41 @@
+@import url("https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600;700&family=Source+Sans+3:wght@400;500;600&display=swap");
+
 :root,
 [data-theme="light"] {
   color-scheme: light;
-  --bg: #f6efe6;
-  --panel: #fdf8f1;
-  --text: #2c261e;
-  --muted: #756753;
-  --accent: #d98321;
-  --accent-strong: #b76916;
-  --border: #e4d6c4;
-  --shadow: rgba(60, 44, 24, 0.12);
-  --page-bg: #f6efe6;
-  --post-bg: #ffffff;
-  --callout-bg: #fff2dc;
-  --button-bg: #14110c;
-  --button-text: #f8f1e6;
-  --button-secondary-text: #d98321;
-  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --bg: #2b2116;
+  --panel: #312516;
+  --text: #f3e9d7;
+  --muted: #c7b193;
+  --accent: #e28a28;
+  --accent-strong: #f1a23c;
+  --border: #463421;
+  --shadow: rgba(16, 10, 5, 0.4);
+  --page-bg: radial-gradient(circle at top, #3a2c1d 0%, #1e160d 55%, #140e08 100%);
+  --post-bg: rgba(36, 27, 18, 0.92);
+  --callout-bg: rgba(226, 138, 40, 0.08);
+  --button-bg: #e28a28;
+  --button-text: #1b1107;
+  --button-secondary-text: #f1a23c;
+  font-family: "Source Sans 3", "Inter", "Segoe UI", system-ui, sans-serif;
 }
 
 [data-theme="dark"] {
   color-scheme: dark;
-  --bg: #100e08;
-  --panel: #18140b;
-  --text: #f5e7bf;
-  --muted: #cbb57a;
-  --accent: #f2c14c;
-  --accent-strong: #ffd75e;
-  --border: #3a2e16;
-  --shadow: rgba(0, 0, 0, 0.45);
-  --page-bg: radial-gradient(circle at top, #1a150b, #0c0a06 60%);
-  --post-bg: rgba(18, 15, 9, 0.9);
-  --callout-bg: rgba(242, 193, 76, 0.08);
-  --button-bg: #2a1f05;
-  --button-text: #f5e7bf;
-  --button-secondary-text: #f2c14c;
+  --bg: #1d140c;
+  --panel: #261a11;
+  --text: #f6ebd4;
+  --muted: #c9b08f;
+  --accent: #e28a28;
+  --accent-strong: #f5a542;
+  --border: #3b2a19;
+  --shadow: rgba(8, 5, 2, 0.5);
+  --page-bg: radial-gradient(circle at top, #2d2115 0%, #1a130b 50%, #110b06 100%);
+  --post-bg: rgba(33, 23, 14, 0.92);
+  --callout-bg: rgba(226, 138, 40, 0.1);
+  --button-bg: #e28a28;
+  --button-text: #1b1107;
+  --button-secondary-text: #f5a542;
 }
 
 * {
@@ -45,6 +47,17 @@ body {
   background: var(--page-bg);
   color: var(--text);
   line-height: 1.6;
+  font-family: "Source Sans 3", "Inter", "Segoe UI", system-ui, sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Playfair Display", "Times New Roman", serif;
+  color: var(--text);
 }
 
 a {
@@ -78,10 +91,10 @@ a:focus {
 }
 
 .site-header {
-  padding: 16px 0 20px;
-  background: var(--panel);
-  border-bottom: 1px solid var(--border);
-  box-shadow: 0 6px 16px var(--shadow);
+  padding: 18px 0 22px;
+  background: linear-gradient(180deg, rgba(32, 23, 13, 0.98), rgba(26, 18, 11, 0.94));
+  border-bottom: 1px solid rgba(226, 138, 40, 0.2);
+  box-shadow: 0 8px 18px var(--shadow);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   position: relative;
@@ -95,13 +108,14 @@ a:focus {
 }
 
 .brand__badge {
-  background: var(--accent);
-  color: #2a1f05;
+  background: rgba(226, 138, 40, 0.18);
+  color: var(--accent);
   padding: 10px 16px;
-  border-radius: 2px;
+  border-radius: 8px;
   font-weight: 700;
-  letter-spacing: 0.12em;
-  font-size: 0.9rem;
+  letter-spacing: 0.16em;
+  font-size: 0.85rem;
+  border: 1px solid rgba(226, 138, 40, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -111,6 +125,7 @@ a:focus {
   font-size: 1.1rem;
   margin: 0;
   letter-spacing: 0.16em;
+  font-family: "Playfair Display", "Times New Roman", serif;
 }
 
 .brand__subtitle {
@@ -139,6 +154,7 @@ a:focus {
   overflow-x: auto;
   padding-bottom: 6px;
   border-bottom: 1px solid var(--border);
+  color: var(--text);
 }
 
 .nav a {
@@ -244,11 +260,11 @@ a:focus {
   display: flex;
   align-items: center;
   gap: 10px;
-  background: var(--post-bg);
-  border: 2px solid #d5d0c7;
+  background: rgba(38, 27, 16, 0.9);
+  border: 1px solid rgba(226, 138, 40, 0.2);
   padding: 10px 14px;
-  border-radius: 8px;
-  box-shadow: 0 6px 12px rgba(55, 45, 30, 0.08);
+  border-radius: 12px;
+  box-shadow: 0 8px 16px rgba(8, 5, 2, 0.35);
 }
 
 .search input {
@@ -266,8 +282,8 @@ a:focus {
   gap: 8px;
   padding: 8px;
   border-radius: 10px;
-  border: 1px solid var(--border);
-  background: var(--post-bg);
+  border: 1px solid rgba(226, 138, 40, 0.25);
+  background: rgba(34, 23, 14, 0.9);
   color: var(--text);
   font-weight: 600;
   cursor: pointer;
@@ -299,16 +315,16 @@ a:focus {
 }
 
 .hero__card {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 18px;
+  background: linear-gradient(180deg, rgba(38, 27, 17, 0.98), rgba(31, 22, 14, 0.96));
+  border: 1px solid rgba(226, 138, 40, 0.15);
+  border-radius: 18px;
+  padding: 20px;
   display: grid;
-  grid-template-columns: minmax(220px, 320px) 1fr;
-  gap: 28px;
+  grid-template-columns: minmax(260px, 420px) 1fr;
+  gap: 32px;
   align-items: center;
   position: relative;
-  box-shadow: 0 6px 16px rgba(31, 19, 8, 0.08);
+  box-shadow: 0 18px 30px rgba(9, 6, 3, 0.4);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -320,11 +336,11 @@ a:focus {
 
 .hero__thumb {
   width: 100%;
-  border-radius: 14px;
-  border: 1px solid var(--border);
-  outline: 1px solid var(--border);
+  border-radius: 16px;
+  border: 1px solid rgba(226, 138, 40, 0.2);
+  outline: 1px solid rgba(15, 10, 5, 0.4);
   object-fit: cover;
-  aspect-ratio: 4 / 5;
+  aspect-ratio: 16 / 9;
 }
 
 .hero__content {
@@ -334,6 +350,9 @@ a:focus {
 
 .hero__card h2 {
   margin-top: 0;
+  font-family: "Playfair Display", "Times New Roman", serif;
+  font-size: clamp(1.6rem, 2.6vw, 2.4rem);
+  line-height: 1.15;
 }
 
 .badge {
@@ -345,18 +364,18 @@ a:focus {
   letter-spacing: 0.2em;
   text-transform: uppercase;
   margin-bottom: 10px;
-  padding: 4px 10px;
-  border: 1px solid var(--accent);
-  border-radius: 6px;
+  padding: 5px 12px;
+  border: 1px solid rgba(226, 138, 40, 0.55);
+  border-radius: 999px;
 }
 
 .hero__card .badge {
-  border: 1px solid #f1dcc4;
+  border: 1px solid rgba(226, 138, 40, 0.6);
   padding: 6px 14px;
   margin: 0;
   font-size: 0.7rem;
   letter-spacing: 0.2em;
-  background: #fff4e5;
+  background: rgba(226, 138, 40, 0.15);
   color: var(--accent-strong);
   border-radius: 999px;
   position: absolute;
@@ -387,12 +406,12 @@ a:focus {
 
 .post {
   border: 1px solid var(--border);
-  background: var(--panel);
-  border-radius: 10px;
+  background: rgba(33, 23, 15, 0.96);
+  border-radius: 14px;
   padding: 18px;
   display: grid;
   gap: 12px;
-  box-shadow: 0 6px 16px rgba(31, 19, 8, 0.08);
+  box-shadow: 0 14px 24px rgba(9, 6, 3, 0.35);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -415,12 +434,12 @@ a:focus {
 
 .post__thumb {
   width: 100%;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  outline: 1px solid var(--border);
+  border-radius: 12px;
+  border: 1px solid rgba(226, 138, 40, 0.2);
+  outline: 1px solid rgba(15, 10, 5, 0.4);
   object-fit: cover;
   aspect-ratio: 16 / 9;
-  box-shadow: 0 8px 18px var(--shadow);
+  box-shadow: 0 10px 20px rgba(8, 5, 2, 0.35);
 }
 
 .post--compact .post__thumb {
@@ -486,7 +505,7 @@ a:focus {
   gap: 6px;
   padding: 4px 10px;
   border-radius: 999px;
-  border: 1px solid var(--border);
+  border: 1px solid rgba(226, 138, 40, 0.3);
   color: var(--accent);
   font-size: 0.8rem;
 }
@@ -586,15 +605,15 @@ a:focus {
 }
 
 .button {
-  border: 1px solid var(--button-bg);
+  border: 1px solid rgba(226, 138, 40, 0.4);
   color: var(--button-text);
-  background: var(--button-bg);
-  padding: 10px 18px;
+  background: linear-gradient(180deg, #f0a13e, #d98220);
+  padding: 11px 20px;
   border-radius: 999px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 10px 20px rgba(11, 7, 3, 0.4);
   transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
 }
 
@@ -614,9 +633,9 @@ a:focus {
 }
 
 .post--compact .button {
-  background: #f4efe9;
-  border-color: #e8ddcf;
-  color: #4b4032;
+  background: rgba(226, 138, 40, 0.15);
+  border-color: rgba(226, 138, 40, 0.4);
+  color: var(--accent);
 }
 
 .post--compact .button:hover {
@@ -654,10 +673,10 @@ a:focus {
 .categories {
   margin-bottom: 24px;
   padding: 18px;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  background: var(--panel);
-  box-shadow: 0 10px 24px var(--shadow);
+  border-radius: 14px;
+  border: 1px solid rgba(226, 138, 40, 0.2);
+  background: rgba(33, 23, 15, 0.96);
+  box-shadow: 0 12px 24px rgba(9, 6, 3, 0.35);
 }
 
 .categories__intro {
@@ -677,8 +696,8 @@ a:focus {
   align-items: center;
   padding: 6px 14px;
   border-radius: 999px;
-  border: 1px solid var(--border);
-  background: var(--callout-bg);
+  border: 1px solid rgba(226, 138, 40, 0.25);
+  background: rgba(226, 138, 40, 0.1);
   color: var(--accent);
   font-size: 0.85rem;
   font-weight: 600;
@@ -706,9 +725,9 @@ a:focus {
 }
 
 .side-panel {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  background: rgba(32, 22, 14, 0.96);
+  border: 1px solid rgba(226, 138, 40, 0.2);
+  border-radius: 14px;
   padding: 18px;
 }
 
@@ -730,7 +749,7 @@ a:focus {
 }
 
 .footer {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid rgba(226, 138, 40, 0.2);
   padding: 24px 0 40px;
   color: var(--muted);
   font-size: 0.9rem;


### PR DESCRIPTION
### Motivation
- Refresh the global palette and typography to a warm, editorial dark direction for the site UI.
- Make headers and hero content feel more typographic and editorial by introducing a serif display face and tuned font sizes.
- Improve contrast, borders, shadows and component surfaces for a richer, warmer presentation across cards and panels.
- Keep the change scoped to styling so markup and JS behavior remain unchanged.

### Description
- Reworked `assets/css/style.css` to replace the previous light/dark variables with a new warm palette and adjusted surface colors and shadows.
- Added a Google Fonts import and set a sans UI stack for body text and `Playfair Display` for headings by updating the `body` and `h1…h6` rules.
- Tuned component styles including header layout, hero card, thumbnails, badges, buttons, category pills, side panels and footers for new radii, gradients, borders and shadows.
- Kept existing CSS structure but updated values for `--accent`, `--accent-strong`, `--button-*`, `--page-bg`, `--post-bg`, and other tokens to align with the new theme.

### Testing
- Started a local static server with `python -m http.server 8000` and rendered `index.html` with a Playwright script to capture a full-page screenshot, which completed successfully and produced an artifact.
- No unit tests or linters were executed for these style-only changes.
- Visual verification was performed via the captured screenshot artifact to ensure layout and typography behave as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958a7bac990832ba76552fca9525af7)