### PR TITLE
Add category pill navigation to category pages and active pill styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -693,6 +693,13 @@ a:focus {
   background: color-mix(in srgb, var(--callout-bg) 80%, var(--accent) 20%);
 }
 
+.category-pill[aria-current="page"],
+.category-pill--active {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--panel);
+}
+
 .bi {
   font-size: 1.1em;
   line-height: 1;

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -47,6 +47,13 @@
         Series, videojuegos y cultura pop con enfoque crítico. Aquí se agrupan las notas marcadas con
         <strong>#entretenimiento</strong>.
       </p>
+      <div class="categories__list" aria-label="Explorar categorías">
+        <a class="category-pill" href="categoria-tecnologia.html">#tecnologia</a>
+        <a class="category-pill" href="categoria-entretenimiento.html" aria-current="page">#entretenimiento</a>
+        <a class="category-pill" href="categoria-ia.html">#ia</a>
+        <a class="category-pill" href="categoria-placeholder.html">#placeholder</a>
+        <a class="category-pill" href="categoria-maqueta.html">#maqueta</a>
+      </div>
       <div class="callout">
         ¿Quieres otra etiqueta? Regresa al <a href="../index.html#secciones">stream de noticias</a> y selecciona una.
       </div>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -47,6 +47,13 @@
         Lo último en inteligencia artificial, modelos, debates éticos y usos creativos. En esta página reunimos
         el contenido con la etiqueta <strong>#ia</strong>.
       </p>
+      <div class="categories__list" aria-label="Explorar categorías">
+        <a class="category-pill" href="categoria-tecnologia.html">#tecnologia</a>
+        <a class="category-pill" href="categoria-entretenimiento.html">#entretenimiento</a>
+        <a class="category-pill" href="categoria-ia.html" aria-current="page">#ia</a>
+        <a class="category-pill" href="categoria-placeholder.html">#placeholder</a>
+        <a class="category-pill" href="categoria-maqueta.html">#maqueta</a>
+      </div>
       <div class="callout">
         Consulta otras etiquetas desde el <a href="../index.html#secciones">stream principal</a>.
       </div>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -47,6 +47,13 @@
         Espacio dedicado a bocetos, exploraciones visuales y pruebas editoriales. Aquí están las notas etiquetadas
         con <strong>#maqueta</strong>.
       </p>
+      <div class="categories__list" aria-label="Explorar categorías">
+        <a class="category-pill" href="categoria-tecnologia.html">#tecnologia</a>
+        <a class="category-pill" href="categoria-entretenimiento.html">#entretenimiento</a>
+        <a class="category-pill" href="categoria-ia.html">#ia</a>
+        <a class="category-pill" href="categoria-placeholder.html">#placeholder</a>
+        <a class="category-pill" href="categoria-maqueta.html" aria-current="page">#maqueta</a>
+      </div>
       <div class="callout">
         Seguimos refinando el diseño del sitio: revisa el <a href="../index.html#secciones">stream principal</a>
         para ver avances recientes.

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -47,6 +47,13 @@
         Contenido de prueba para validar layouts y componentes. Aquí quedan agrupadas las entradas etiquetadas como
         <strong>#placeholder</strong>.
       </p>
+      <div class="categories__list" aria-label="Explorar categorías">
+        <a class="category-pill" href="categoria-tecnologia.html">#tecnologia</a>
+        <a class="category-pill" href="categoria-entretenimiento.html">#entretenimiento</a>
+        <a class="category-pill" href="categoria-ia.html">#ia</a>
+        <a class="category-pill" href="categoria-placeholder.html" aria-current="page">#placeholder</a>
+        <a class="category-pill" href="categoria-maqueta.html">#maqueta</a>
+      </div>
       <div class="callout">
         Cuando haya artículos finales, esta categoría servirá para pruebas internas y prototipos visuales.
       </div>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -47,6 +47,13 @@
         Noticias, análisis y actualizaciones clave de hardware, software y cultura digital. Aquí reunimos las piezas
         etiquetadas con <strong>#tecnologia</strong>.
       </p>
+      <div class="categories__list" aria-label="Explorar categorías">
+        <a class="category-pill" href="categoria-tecnologia.html" aria-current="page">#tecnologia</a>
+        <a class="category-pill" href="categoria-entretenimiento.html">#entretenimiento</a>
+        <a class="category-pill" href="categoria-ia.html">#ia</a>
+        <a class="category-pill" href="categoria-placeholder.html">#placeholder</a>
+        <a class="category-pill" href="categoria-maqueta.html">#maqueta</a>
+      </div>
       <div class="callout">
         ¿Buscas más temas? Vuelve al <a href="../index.html#secciones">stream de noticias</a> y explora otras etiquetas.
       </div>


### PR DESCRIPTION
### Motivation
- Provide consistent, discoverable category navigation on each category page to match the categories block on the homepage.
- Visually indicate the current category so users can quickly see which tag is active.
- Keep styles centralized in the global stylesheet for consistent appearance across pages.

### Description
- Added a `div` with class `categories__list` containing `.category-pill` links to each category in all `pages/categoria-*.html` files.
- Marked the current page's pill using `aria-current="page"` on the appropriate `.category-pill` link.
- Extended `assets/css/style.css` with an active state selector ` .category-pill[aria-current="page"], .category-pill--active { ... }` to set `border-color`, `background`, and `color` for the active pill.
- Changes applied to `pages/categoria-tecnologia.html`, `pages/categoria-entretenimiento.html`, `pages/categoria-ia.html`, `pages/categoria-placeholder.html`, `pages/categoria-maqueta.html`, and `assets/css/style.css`.

### Testing
- Started a local server with `python -m http.server 8000` and verified pages load without errors.
- Ran a Playwright script that opened `http://127.0.0.1:8000/pages/categoria-tecnologia.html` and successfully saved a screenshot to `artifacts/categoria-tecnologia.png`.
- No automated unit or integration test suites were executed as part of this change.
- Visual check via the generated screenshot confirmed the active pill styling is applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695920e85690832ba0b57ea512db62ca)