### PR TITLE
Add keyboard `:focus-visible` styles to header nav and menu links

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -155,6 +155,13 @@ a:focus {
   color: var(--accent);
 }
 
+.nav a:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+}
+
 .nav a.active::before {
   content: "./";
   margin-right: 4px;
@@ -221,6 +228,13 @@ a:focus {
 .nav-menu__panel a:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+.nav-menu__panel a:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
 }
 
 .nav-menu__panel a.active::before {


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility by making focus states for header navigation and menu links clearly visible.
- Ensure the focus state matches the existing hover/active visual language (accent border and text) while remaining distinct from hover.
- Provide an additional visible outline to help keyboard users locate focused items in the header.

### Description
- Added `.nav a:focus-visible` rules to `assets/css/style.css` to apply `border-color: var(--accent)`, `color: var(--accent)`, and an accent outline with `outline-offset`.
- Added `.nav-menu__panel a:focus-visible` rules to `assets/css/style.css` mirroring the header nav focus styling with a slightly smaller `outline-offset`.
- The focus styles match the existing `.nav a:hover` and `.nav-menu__panel a:hover` accent styling to keep visual consistency.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script that navigates to `index.html`, tabs to the header nav, and captured a screenshot at `artifacts/nav-focus.png`, which completed successfully.
- The change is a static CSS update with no unit tests required and no automated failures were encountered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695921bdd79c832b954a55f65f5d32d3)