### PR TITLE
Clamp compact post excerpts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -425,6 +425,14 @@ a:focus {
 .post--compact .post__body {
   display: grid;
   gap: 10px;
+  min-height: 110px;
+}
+
+.post--compact .post__body p {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .post__thumb {


### PR DESCRIPTION
### Motivation

- Limit the length of excerpt text in compact post cards to keep listings tidy and consistent.
- Ensure full post pages are unaffected by scoping the change to compact cards.
- Stabilize card heights so layout doesn't shift when excerpts vary in length.

### Description

- Updated `assets/css/style.css` to add a `min-height: 110px` to the ` .post--compact .post__body` rule to stabilize card heights.
- Added a line-clamp to ` .post--compact .post__body p` using `display: -webkit-box`, `-webkit-line-clamp: 3`, `-webkit-box-orient: vertical`, and `overflow: hidden` to truncate excerpts to three lines.
- The clamping selector is explicitly scoped to ` .post--compact` so full post pages are not affected.

### Testing

- Served the site with `python -m http.server` and captured a rendering of `index.html` using a Playwright script, producing `artifacts/compact-posts.png`, and the screenshot was generated successfully.
- No automated unit tests were run against the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695922a66724832b8bd6a2eea31f96a6)