### PR TITLE
Adjust hero badge layout on mobile

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1137,6 +1137,14 @@ a:focus {
     justify-items: start;
   }
 
+  .hero__card .badge {
+    position: static;
+    margin-bottom: 8px;
+    align-self: flex-start;
+    padding: 4px 12px;
+    background: #fff8ef;
+  }
+
   .hero__thumb {
     width: 100%;
     height: auto;


### PR DESCRIPTION
### Motivation
- Prevent the hero `.badge` from overlapping the hero thumbnail on small screens.
- Preserve a visible badge style on mobile while avoiding obstruction of the image.
- Keep the mobile hero card content in normal flow for consistent spacing.

### Description
- Add rules inside `@media (max-width: 720px)` targeting `.hero__card .badge` to set `position: static`, `margin-bottom: 8px`, and `align-self: flex-start`.
- Adjust mobile badge `padding` to `4px 12px` and set a lighter `background: #fff8ef` to maintain prominence without covering the image.
- Change is CSS-only and does not modify HTML structure or desktop styles.

### Testing
- Served the site and captured a headless Playwright screenshot of `index.html` at a `700x900` viewport to verify the badge no longer overlaps the thumbnail, and the capture completed successfully.
- No unit or integration test suite was applicable for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69592659ff18832b9ee5e5ee8e1fe4e2)