### PR TITLE
Mejorar legibilidad del stream de posts

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -455,7 +455,7 @@ a:focus {
 
 .post--compact .post__body {
   display: grid;
-  gap: 10px;
+  gap: 12px;
   min-height: 110px;
 }
 
@@ -464,6 +464,7 @@ a:focus {
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  margin: 0;
 }
 
 .post__thumb {
@@ -487,7 +488,7 @@ a:focus {
   flex-wrap: wrap;
   gap: 14px;
   font-size: 0.82rem;
-  color: var(--muted);
+  color: var(--accent-strong);
 }
 
 .post__toc {
@@ -620,6 +621,9 @@ a:focus {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  padding-top: 12px;
+  margin-top: 4px;
 }
 
 .post--compact .post__actions {


### PR DESCRIPTION
### Motivation
- Aumentar el contraste y la separación visual en las tarjetas del stream para mejorar la lectura en bloque.
- Hacer que los metadatos de cada publicación destaquen más frente al fondo. 
- Añadir una separación suave antes de las acciones del post para clarificar la jerarquía visual.

### Description
- Incrementa el espacio interno en ` .post--compact .post__body` cambiando `gap` de `10px` a `12px` y quita márgenes extra en los extractos con `margin: 0` en ` .post--compact .post__body p`.
- Refuerza el contraste de los metadatos reemplazando `color: var(--muted)` por `color: var(--accent-strong)` en ` .post__meta`.
- Añade un separador sutil antes de las acciones mediante `border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent)` y agrega `padding-top` y `margin-top` en ` .post__actions`.
- Captura una vista actualizada del stream para verificación visual (`artifacts/index-stream.png`).

### Testing
- Levantado un servidor estático con `python -m http.server 8000` y la operación finalizó correctamente.
- Ejecutado un script de Playwright para cargar `index.html` y producir `artifacts/index-stream.png`, el script se completó con éxito.
- No se ejecutaron pruebas unitarias porque los cambios son modificaciones CSS estáticas.
- El cambio en `assets/css/style.css` fue añadido y registrado en el repositorio con commit exitoso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695929ead1b8832bad9d6a33ee2f8d13)