### PR TITLE
Unify hero and post thumbnail aspect ratios and border radii

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -365,11 +365,11 @@ a:focus {
 
 .hero__thumb {
   width: 100%;
-  border-radius: 14px;
+  border-radius: 10px;
   border: 1px solid var(--border);
   outline: 1px solid var(--border);
   object-fit: cover;
-  aspect-ratio: 4 / 5;
+  aspect-ratio: 16 / 9;
 }
 
 .hero__content {
@@ -473,14 +473,14 @@ a:focus {
   border: 1px solid var(--border);
   outline: 1px solid var(--border);
   object-fit: cover;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: 4 / 3;
   box-shadow: 0 8px 18px var(--shadow);
 }
 
 .post--compact .post__thumb {
   width: 130px;
-  height: 130px;
-  aspect-ratio: 1;
+  height: auto;
+  aspect-ratio: 4 / 3;
 }
 
 .post__meta {
@@ -1201,7 +1201,7 @@ a:focus {
   .post--compact .post__thumb {
     width: 100%;
     height: auto;
-    aspect-ratio: 16 / 9;
+    aspect-ratio: 4 / 3;
   }
 
   .post__actions {


### PR DESCRIPTION
### Motivation
- Make thumbnail images consistent with the theme by applying matching `aspect-ratio` and `object-fit` rules. 
- Align thumbnail `border-radius` with other UI elements to create a cohesive look.
- Ensure image containers do not break layout spacing inside `hero__card` and `post` components.

### Description
- Updated `.hero__thumb` to use `aspect-ratio: 16 / 9` and reduced `border-radius` from `14px` to `10px` while keeping `object-fit: cover` and borders. 
- Changed `.post__thumb` default to `aspect-ratio: 4 / 3` and preserved `object-fit: cover` and existing borders/shadow. 
- Adjusted `.post--compact .post__thumb` from a fixed `130px` square to `height: auto` with `aspect-ratio: 4 / 3` so compact thumbnails maintain the new proportions. 
- Updated responsive/mobile overrides to match the new `4 / 3` aspect ratio for compact post thumbnails.

### Testing
- Served the site with `python -m http.server` and ran a Playwright script to load `index.html` and capture a screenshot (`artifacts/hero-post-thumbs.png`), which completed successfully. 
- No unit tests applicable for these static CSS changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69592cb46368832b946064f6a050a86b)