### PR TITLE
Update body typography and preserve monospace for UI

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,7 +15,8 @@
   --button-bg: #14110c;
   --button-text: #f8f1e6;
   --button-secondary-text: #d98321;
-  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --font-body: "Inter", "Source Sans 3", system-ui, sans-serif;
+  --font-ui: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
 }
 
 [data-theme="dark"] {
@@ -44,7 +45,8 @@ body {
   margin: 0;
   background: var(--page-bg);
   color: var(--text);
-  line-height: 1.6;
+  font-family: var(--font-body);
+  line-height: 1.7;
 }
 
 a {
@@ -1254,4 +1256,33 @@ a:focus {
   .footer {
     padding: 20px 0 32px;
   }
+}
+.hero__content p,
+.post__body p,
+.categories__intro {
+  font-family: var(--font-body);
+  line-height: 1.7;
+}
+
+.nav,
+.nav-menu,
+.nav-menu__panel,
+.brand__badge,
+.badge,
+.post__meta,
+.post__toc-title,
+.post__tags span,
+.button,
+.search button,
+.search input,
+.theme-toggle,
+.section-title,
+.category-pill,
+.filter-panel__title,
+.filter-chip,
+.search-results__label,
+.result-card__meta,
+.result-card__badge,
+.search__prompt {
+  font-family: var(--font-ui);
 }


### PR DESCRIPTION
### Motivation
- Introduce a readable body font stack and improve copy rhythm for long-form content.
- Preserve the existing monospace UI font for navigation, badges, buttons, and metadata to keep the current UI aesthetic.
- Expose separate CSS variables for body and UI fonts to make future typography adjustments easier.

### Description
- Add `--font-body` and `--font-ui` CSS variables in `:root` and replace the global `font-family` with `var(--font-body)` on `body`.
- Increase body copy `line-height` from `1.6` to `1.7` and explicitly apply the body font + line-height to ` .hero__content p`, `.post__body p`, and `.categories__intro`.
- Apply the monospace UI font (`var(--font-ui)`) to navigation, badges, buttons, metadata, and other UI elements via a grouped selector list.
- Modified file: `assets/css/style.css`.

### Testing
- Performed a local visual check by starting a static server with `python -m http.server 8000` and running a Playwright script to capture a full-page screenshot, which completed and produced `artifacts/body-font-update.png`.
- No automated unit or integration tests were applicable for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69592d894778832b9a1ed0fb8aa995bc)