### PR TITLE
Use IBM Plex Sans for body typography

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,7 +15,7 @@
   --button-bg: #14110c;
   --button-text: #f8f1e6;
   --button-secondary-text: #d98321;
-  --font-body: "Inter", "Source Sans 3", system-ui, sans-serif;
+  --font-body: "IBM Plex Sans", "Inter", "Source Sans 3", system-ui, sans-serif;
   --font-ui: "JetBrains Mono", "Fira Code", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
 }
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <meta name="twitter:title" content="ANXiNA" />
   <meta name="twitter:description" content="Noticias de tecnología, ciencia y videojuegos con señal clara." />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
   <script type="application/ld+json">

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Benefactores</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Entretenimiento</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría IA</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Maqueta</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Placeholder</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Tecnología</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Contáctanos</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Política de privacidad</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Términos de servicio</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>


### PR DESCRIPTION
### Motivation
- Prefer `IBM Plex Sans` as the primary body font to improve typography consistency and readability across the site.
- Ensure the font is loaded on every page so the CSS font stack can reliably use it.

### Description
- Updated `assets/css/style.css` to set `--font-body` to `"IBM Plex Sans", "Inter", "Source Sans 3", system-ui, sans-serif`.
- Added the Google Fonts stylesheet link for `IBM Plex Sans` to `index.html` and top-level pages under `pages/*.html` so the font is downloaded by browsers.
- Modified files include `assets/css/style.css`, `index.html`, and the HTML files in `pages/`.

### Testing
- Launched a local static server with `python -m http.server 8000`, which started successfully.
- Rendered the homepage with `Playwright` and captured a screenshot saved to `artifacts/ibm-plex-home.png`, which completed successfully.
- No automated unit tests were added for this static styling change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695930096f3c832b9ce8a95c675014d0)