### PR TITLE
Replace header search bar with 'Buscar' menu link

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,21 +46,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a class="active" href="index.html" aria-current="page">Inicio</a>
             <a href="#secciones">Secciones/Categorías</a>
+            <a href="search.html">Buscar</a>
             <a href="pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input
-            id="site-search"
-            type="search"
-            name="q"
-            placeholder="buscar..."
-            aria-controls="stream"
-            autocomplete="off"
-          />
-          <button type="submit">Buscar</button>
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -26,13 +26,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="../search.html">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="../search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" name="q" placeholder="buscar..." />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>

--- a/search.html
+++ b/search.html
@@ -36,18 +36,10 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="index.html">Inicio</a>
             <a href="index.html#secciones">Secciones/Categorías</a>
+            <a href="search.html">Buscar</a>
             <a href="pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <form class="search" role="search" action="search.html" method="get" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input
-            type="search"
-            name="q"
-            placeholder="buscar..."
-            autocomplete="off"
-          />
-        </form>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>


### PR DESCRIPTION
### Motivation

- Remove the inline header search input to centralize searching on the dedicated search page.
- Simplify the header UI and avoid duplicated search controls across pages.

### Description

- Add a `Buscar` link to the main navigation in `index.html`, `search.html` and the pages under `pages/` that point to the dedicated `search.html` (paths adjusted per page).
- Remove the header search form (`<form class="search">`) from `index.html`, `search.html` and the site pages so the full search UI remains only on `search.html`.
- Files modified include `index.html`, `search.html`, and the following under `pages/`: `benefactores.html`, `categoria-entretenimiento.html`, `categoria-ia.html`, `categoria-maqueta.html`, `categoria-placeholder.html`, `categoria-tecnologia.html`, `contactanos.html`, `politica_de_privacidad.html`, and `terminos_de_servicio.html`.

### Testing

- Served the site locally with `python -m http.server 8000` and ran a Playwright script to load `index.html` and capture a screenshot to verify the `Buscar` link appears in the header navigation, which completed successfully and produced an artifact.
- No unit or integration test suite was run since this is a static markup change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959352e9854832bae28b56d2e42a7a5)