### PR TITLE
Fix page links and normalize styles

### DIFF
--- a/pages/404.html
+++ b/pages/404.html
@@ -4,26 +4,30 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · 404</title>
-  <link rel="stylesheet" href="assets/css/style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="../assets/css/style.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>
 <body>
   <a class="skip-link" href="#contenido">Saltar al contenido</a>
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <div class="brand__badge">
-          <h1 class="brand__title">ANXiNA</h1>
-        </div>
+        <a class="brand__link" href="../index.html">
+          <div class="brand__badge">
+            <h1 class="brand__title">ANXiNA</h1>
+          </div>
+        </a>
         <p class="brand__subtitle">Noticias de tecnología, ciencia y videojuegos con señal clara.</p>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
-          <summary><span class="material-symbols-outlined" aria-hidden="true">menu</span><span>Menú</span></summary>
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="index.html">Inicio</a>
-            <a href="index.html#secciones">Secciones/Categorías</a>
-            <a href="pages/contactanos.html">Contáctanos</a>
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
+            <a href="search.html">Buscar</a>
+            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <label class="search" aria-label="Buscar en ANXiNA">
@@ -50,20 +54,20 @@
           <h3>Retomar la transmisión</h3>
           <p>Regresa al stream principal o explora las categorías destacadas para no perder el hilo.</p>
           <div class="post__actions">
-            <a class="button" href="index.html">Volver al inicio</a>
+            <a class="button" href="../index.html">Volver al inicio</a>
           </div>
         </div>
         <div class="side-panel">
           <h3>Atajos útiles</h3>
           <ul>
-            <li><span>#tecnologia</span><span><a href="pages/categoria-tecnologia.html">Ir ahora</a></span></li>
-            <li><span>#ia</span><span><a href="pages/categoria-ia.html">Ir ahora</a></span></li>
-            <li><span>#entretenimiento</span><span><a href="pages/categoria-entretenimiento.html">Ir ahora</a></span></li>
+            <li><span>#tecnologia</span><span><a href="categoria-tecnologia.html">Ir ahora</a></span></li>
+            <li><span>#ia</span><span><a href="categoria-ia.html">Ir ahora</a></span></li>
+            <li><span>#entretenimiento</span><span><a href="categoria-entretenimiento.html">Ir ahora</a></span></li>
           </ul>
         </div>
       </div>
       <div class="callout" style="margin-top: 24px;">
-        Si llegaste aquí por un enlace roto, avísanos en <a href="pages/contactanos.html">Contáctanos</a> para
+        Si llegaste aquí por un enlace roto, avísanos en <a href="contactanos.html">Contáctanos</a> para
         corregirlo.
       </div>
     </div>
@@ -72,13 +76,13 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="pages/contactanos.html">Contáctanos</a>. Consulta nuestra
-        <a href="pages/politica_de_privacidad.html">política de privacidad</a> y los
-        <a href="pages/terminos_de_servicio.html">términos</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>
-  <script src="assets/js/theme-toggle.js"></script>
-  <script src="assets/js/nav-menu.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
 </body>
 </html>

--- a/pages/search.html
+++ b/pages/search.html
@@ -15,7 +15,8 @@
   <meta name="twitter:title" content="ANXiNA · Resultados de búsqueda" />
   <meta name="twitter:description" content="Encuentra noticias, reseñas y reportajes en ANXiNA." />
   <meta name="theme-color" content="#0c0a06" />
-  <link rel="stylesheet" href="assets/css/style.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
+  <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
 </head>
 <body>
@@ -23,7 +24,7 @@
   <header class="site-header">
     <div class="container">
       <div class="brand">
-        <a class="brand__link" href="index.html">
+        <a class="brand__link" href="../index.html">
           <div class="brand__badge">
             <h1 class="brand__title">ANXiNA</h1>
           </div>
@@ -34,10 +35,10 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="index.html">Inicio</a>
-            <a href="index.html#secciones">Secciones/Categorías</a>
+            <a href="../index.html">Inicio</a>
+            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="pages/contactanos.html">Contáctanos</a>
+            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -124,7 +125,7 @@
 
           <div class="search-results__list">
             <article class="result-card">
-              <img class="result-card__thumb" src="assets/img/pebe1.png" alt="Pantalla con código en una laptop" />
+              <img class="result-card__thumb" src="../assets/img/pebe1.png" alt="Pantalla con código en una laptop" />
               <div class="result-card__content">
                 <div class="result-card__meta">
                   <span class="result-card__badge">Videojuegos</span>
@@ -144,7 +145,7 @@
             </article>
 
             <article class="result-card">
-              <img class="result-card__thumb" src="assets/img/2025anxina.png" alt="Composición editorial con dispositivos y gráficos" />
+              <img class="result-card__thumb" src="../assets/img/2025anxina.png" alt="Composición editorial con dispositivos y gráficos" />
               <div class="result-card__content">
                 <div class="result-card__meta">
                   <span class="result-card__badge result-card__badge--tech">Tech</span>
@@ -164,7 +165,7 @@
             </article>
 
             <article class="result-card">
-              <img class="result-card__thumb" src="assets/img/ram-ia.png" alt="Ilustración de módulos de RAM en contexto de IA" />
+              <img class="result-card__thumb" src="../assets/img/ram-ia.png" alt="Ilustración de módulos de RAM en contexto de IA" />
               <div class="result-card__content">
                 <div class="result-card__meta">
                   <span class="result-card__badge result-card__badge--science">Ciencia</span>
@@ -184,7 +185,7 @@
             </article>
 
             <article class="result-card">
-              <img class="result-card__thumb" src="assets/img/pebe2.png" alt="Control retro de videojuegos" />
+              <img class="result-card__thumb" src="../assets/img/pebe2.png" alt="Control retro de videojuegos" />
               <div class="result-card__content">
                 <div class="result-card__meta">
                   <span class="result-card__badge result-card__badge--review">Review</span>
@@ -218,14 +219,14 @@
   <footer class="footer">
     <div class="container">
       <p>
-        ANXiNA · Tecnología con criterio. Escríbenos en <a href="pages/contactanos.html">Contáctanos</a>. Consulta nuestra
-        <a href="pages/politica_de_privacidad.html">política de privacidad</a> y los
-        <a href="pages/terminos_de_servicio.html">términos</a>.
+        ANXiNA · Tecnología con criterio. Escríbenos en <a href="contactanos.html">Contáctanos</a>. Consulta nuestra
+        <a href="politica_de_privacidad.html">política de privacidad</a> y los
+        <a href="terminos_de_servicio.html">términos</a>.
       </p>
     </div>
   </footer>
-  <script src="assets/js/theme-toggle.js"></script>
-  <script src="assets/js/nav-menu.js"></script>
-  <script src="assets/js/search-page.js"></script>
+  <script src="../assets/js/theme-toggle.js"></script>
+  <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/search-page.js"></script>
 </body>
 </html>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/2025anxina.png" />
   <meta name="twitter:image:alt" content="Composición editorial sobre el año 2025 en tecnología y cultura" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/ram-ia.png" />
   <meta name="twitter:image:alt" content="Ilustración de módulos de RAM junto a un chip con temática de inteligencia artificial" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/pebe1.png" />
   <meta name="twitter:image:alt" content="pebe2.png" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-1.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 1" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-2.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 2" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-3.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 3" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-4.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 4" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-5.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 5" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-6.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 6" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-7.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 7" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -22,9 +22,9 @@
   <meta name="twitter:image" content="../assets/img/placeholder-8.jpg" />
   <meta name="twitter:image:alt" content="Imagen de relleno para el post 8" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
### Motivation

- Ensure relative links, asset references and images resolve correctly from pages under `pages/` and `posts/` so the site navigation works when served from the static tree. 
- Standardize the site font and icon usage to a single, consistent set across pages and posts. 
- Remove unused `Material Symbols` font from post templates and replace with the global font and `bootstrap-icons` to avoid mixed icon/font imports. 

### Description

- Updated `pages/404.html` and `pages/search.html` to correct relative paths for CSS/JS/images/links and aligned header markup (added `brand__link` and replaced `material-symbols` markup with `bootstrap-icons`).
- Normalized asset references in `pages/search.html` and `pages/404.html` to use `../assets/...` where appropriate and updated image `src` paths in `pages/search.html` to `../assets/img/...`.
- Removed the `Material Symbols` stylesheet from multiple `posts/*.html` and inserted the `IBM Plex Sans` font plus `bootstrap-icons` reference for consistent typography and icons across posts.
- Ran an automated script to remove `Material+Symbols` entries and insert the `IBM Plex Sans` link into post templates.

### Testing

- Ran an automated local link-target check (script that parses `a[href]` and resolves local paths) which reported `Missing local link targets: 0` and thus succeeded. 
- Inspected stylesheet sets across HTML files with a parser script to verify stylesheet normalization, confirming the font and `../assets/css/style.css` were applied to the post files. 
- Served the site with `python -m http.server 8000` and used Playwright to open `http://127.0.0.1:8000/pages/search.html` and capture a screenshot, which completed successfully. 
- No unit test suite was run because these are static HTML/CSS changes, and all automated validation scripts completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69594a9bcccc832b83b7ba99a669ca58)