### PR TITLE
Style .header-meta control bar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -126,8 +126,12 @@ a:focus {
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  margin-top: 18px;
+  margin-top: 16px;
   flex-wrap: wrap;
+  padding: 12px 16px;
+  background: var(--post-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
 }
 
 .nav {


### PR DESCRIPTION
### Motivation
- Make the header meta area visually distinct and act like a compact control bar by adding padding and a subtle background.  
- Add a thin border and rounded corners to improve separation from surrounding content.  
- Tighten spacing to better balance the header meta with the brand area while preserving responsive wrapping.

### Description
- Reduced `.header-meta` top margin from `18px` to `16px` for tighter spacing.  
- Added `padding: 12px 16px`, `background: var(--post-bg)`, `border: 1px solid var(--border)`, and `border-radius: 12px` to the `.header-meta` rule.  
- Kept `display: flex`, `gap`, and `flex-wrap: wrap` so the menu area continues to wrap cleanly on small screens.

### Testing
- Started a local dev server using `python -m http.server 8000` which served the site for manual inspection.  
- Attempted an automated Playwright screenshot, but the browser crashed with a `SIGSEGV` so visual verification did not complete.  
- No automated unit or visual tests were completed successfully after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69596430fa78832b873ee318e153531f)