### PR TITLE
Style nav menu summary as button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -189,8 +189,10 @@ a:focus {
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  padding-bottom: 4px;
-  border-bottom: 2px solid transparent;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--callout-bg);
   color: inherit;
 }
 
@@ -202,6 +204,7 @@ a:focus {
 .nav-menu > summary:hover,
 .nav-menu > summary:focus-visible {
   border-color: var(--accent);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
 }
 
 .nav-menu__panel {


### PR DESCRIPTION
### Motivation

- Make the navigation details `summary` look and behave like a clickable button to improve affordance.
- Add all-around padding, a subtle background, and rounded corners while avoiding changes to the menu panel layout.
- Reinforce hover and focus states so keyboard and pointer users perceive clickability.

### Description

- Update the ` .nav-menu > summary` rule to use `padding: 6px 12px`, a pill `border-radius`, a subtle `background: var(--callout-bg)`, and a transparent `border` instead of the bottom underline.
- Preserve hiding the native marker with `:: -webkit-details-marker` and do not modify the `.nav-menu__panel` layout or sizing.
- Enhance the interactive state selector (`.nav-menu[open] > summary, .nav-menu > summary:hover, .nav-menu > summary:focus-visible`) to set `border-color: var(--accent)` and add a subtle `box-shadow` for hover/focus feedback.

### Testing

- Served the site locally with `python -m http.server` to validate styles were applied, and the server started successfully.
- Captured a visual snapshot using a Playwright script which produced a screenshot artifact of the updated menu (success).
- No unit tests were run for this static CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695972c68c8c832bb2c6a0c1c108a7f1)