### PR TITLE
Adjust .header-meta spacing and add subtle top divider

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -126,11 +126,12 @@ a:focus {
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  margin-top: 16px;
+  margin-top: 24px;
   flex-wrap: wrap;
-  padding: 12px 16px;
+  padding: 18px 16px 14px;
   background: var(--post-bg);
   border: 1px solid var(--border);
+  border-top: 1px solid var(--border);
   border-radius: 12px;
 }
 
@@ -1124,7 +1125,8 @@ a:focus {
   .header-meta {
     gap: 12px;
     width: 100%;
-    padding: 16px;
+    margin-top: 20px;
+    padding: 20px 16px 16px;
     border-radius: 12px;
     border: 1px solid var(--border);
     background: var(--post-bg);


### PR DESCRIPTION
### Motivation
- Create more vertical breathing room above the header meta area for improved visual separation.
- Add a gentle divider to the header meta to help delineate it from the header content.
- Ensure the header meta spacing remains balanced on smaller viewports.

### Description
- Increased `.header-meta` desktop `margin-top` from `16px` to `24px` and adjusted padding to `18px 16px 14px` in `assets/css/style.css`.
- Added an explicit `border-top: 1px solid var(--border)` to introduce a subtle divider for `.header-meta`.
- Tweaked mobile `.header-meta` to add `margin-top: 20px` and new padding `20px 16px 16px` to maintain balanced spacing on small screens.
- Committed the changes with the message `Adjust header meta spacing`.

### Testing
- Launched a local server with `python -m http.server 8000` and confirmed the site served successfully.
- Executed a Playwright script that captured desktop (`1200x800`) and mobile (`390x844`) screenshots saved as `header-meta-desktop.png` and `header-meta-mobile.png`, and both captures completed successfully.
- No unit tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695974e8bdd4832b9dc399f3bf80a213)