### PR TITLE
Align .header-meta content to the right on wide screens

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -135,6 +135,12 @@ a:focus {
   border-radius: 12px;
 }
 
+@media (min-width: 721px) {
+  .header-meta {
+    justify-content: flex-end;
+  }
+}
+
 .nav {
   display: flex;
   flex-wrap: nowrap;


### PR DESCRIPTION
### Motivation
- Align the children of `.header-meta` to the right on wider viewports to improve header layout on desktop screens.
- Preserve the current wrapping behavior for smaller screens by keeping `flex-wrap` in the base rule.
- Ensure the existing `theme-toggle` alignment relative to the menu trigger remains unaffected.

### Description
- Add a `@media (min-width: 721px)` rule that sets `.header-meta { justify-content: flex-end; }`.
- Leave the existing `.header-meta` base rule intact, including `flex-wrap: wrap` and other spacing styles.
- No changes were made to `.theme-toggle` or `.nav`, so their alignment behavior is preserved.

### Testing
- Launched a local server with `python -m http.server 8000` and ran a Playwright script to open `index.html` at `1280x720` for a visual verification.
- The Playwright run saved a screenshot to `artifacts/header-meta.png` and the visual check confirmed the header-meta content aligns to the right on desktop while the theme toggle remains aligned.
- No automated unit tests were executed for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69597ec10aa4832bb7166d6448675d32)