### PR TITLE
Remove drop shadow on mobile nav menu summary when open

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1199,6 +1199,10 @@ a:focus {
     background: var(--callout-bg);
   }
 
+  .nav-menu[open] > summary {
+    box-shadow: none;
+  }
+
   .nav-menu__panel {
     position: static;
     width: 100%;


### PR DESCRIPTION
### Motivation
- The mobile navigation shows an odd visual element beneath the menu when the `details` menu is open, caused by a drop shadow on the summary.  
- This creates a distracting or duplicate shadow on small screens and should be removed for a cleaner UI.  
- The change targets only the mobile layout so desktop appearance is preserved.  

### Description
- Added a CSS rule ` .nav-menu[open] > summary { box-shadow: none; }` to `assets/css/style.css` to remove the shadow when the mobile menu is open.  
- The rule is applied inside the mobile styles so it only affects the stacked/mobile header layout.  
- No JavaScript changes were made.  

### Testing
- Started a local server with `python -m http.server 8000` to load the site for visual verification (succeeded).  
- Attempted to run a Playwright script that opens the page and clicks the mobile menu to capture a screenshot, but the Chromium process crashed and the script failed.  
- No automated unit tests were added or run for this static style change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959953ff32c832b89ab89696c7991ca)