### PR TITLE
Refine header theme toggle styling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -147,11 +147,7 @@ a:focus {
   gap: 16px;
   margin-top: 24px;
   flex-wrap: wrap;
-  padding: 18px 16px 14px;
-  background: var(--post-bg);
-  border: 1px solid var(--border);
-  border-top: 1px solid var(--border);
-  border-radius: 12px;
+  padding: 0;
 }
 
 @media (min-width: 721px) {
@@ -1163,11 +1159,7 @@ a:focus {
     gap: 12px;
     width: 100%;
     margin-top: 20px;
-    padding: 20px 16px 16px;
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    background: var(--post-bg);
-    box-shadow: 0 10px 24px var(--shadow);
+    padding: 0;
   }
 
   .nav {


### PR DESCRIPTION
### Motivation
- The theme toggle was visually enclosed in a large white/post-background bar because the header metadata container had padding and background styles.  
- The change aims to remove that distracting white area so the toggle integrates with the header across themes.  

### Description
- Removed padding and background-related styles from `.header-meta` in `assets/css/style.css` so the toggle no longer sits inside a large `--post-bg` box.  
- Removed the mobile-specific padding/background/box-shadow for `.header-meta` inside the `(max-width: 720px)` media query to keep behavior consistent on small screens.  
- Preserved existing layout properties (flex, gap, alignment) so navigation and header items continue to align as before.  

### Testing
- Started a static server with `python -m http.server` and served the site successfully.  
- Ran a Playwright script that loaded `index.html` and captured a verification screenshot `artifacts/theme-toggle-header.png` showing the updated header.  
- No unit tests were added or run for this visual/style-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69599752372c832b8d6cf6b0f50910db)