### PR TITLE
Align portada card with stream layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -386,9 +386,9 @@ a:focus {
   border-radius: 10px;
   padding: 18px;
   display: grid;
-  grid-template-columns: minmax(220px, 320px) 1fr;
-  gap: 28px;
-  align-items: center;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  align-items: start;
   position: relative;
   box-shadow: 0 6px 16px rgba(31, 19, 8, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -446,9 +446,8 @@ a:focus {
   background: #fff4e5;
   color: var(--accent-strong);
   border-radius: 999px;
-  position: absolute;
-  top: 18px;
-  right: 18px;
+  position: static;
+  align-self: flex-start;
 }
 
 .hero__card .badge::before,

--- a/index.html
+++ b/index.html
@@ -69,11 +69,11 @@
     <section class="hero">
       <div class="container hero__grid">
         <!-- portada:begin -->
-        <article class="hero__card">
+        <article class="post post--compact hero__card">
           <a href="posts/pebble-round-2-volver-a-lo-esencial.html">
-            <img class="hero__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
+            <img class="post__thumb hero__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
           </a>
-          <div class="hero__content">
+          <div class="post__body hero__content">
             <div class="badge">En portada</div>
             <h2>
               <a class="post__title-link" href="posts/pebble-round-2-volver-a-lo-esencial.html">Pebble Round 2: volver a lo esencial también es avanzar</a>

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -184,11 +184,11 @@ STREAM_ITEM_TEMPLATE = """        <article class="post post--compact">
           </div>
         </article>"""
 
-HERO_TEMPLATE = """        <article class="hero__card">
+HERO_TEMPLATE = """        <article class="post post--compact hero__card">
           <a href="posts/{slug}.html">
-            <img class="hero__thumb" src="{image}" alt="{alt}" />
+            <img class="post__thumb hero__thumb" src="{image}" alt="{alt}" />
           </a>
-          <div class="hero__content">
+          <div class="post__body hero__content">
             <div class="badge">En portada</div>
             <h2>
               <a class="post__title-link" href="posts/{slug}.html">{title}</a>


### PR DESCRIPTION
### Motivation
- Make the portada (hero) card visually consistent with the rest of the stream by reusing the same card structure and styles.
- Reduce duplicated markup and CSS by aligning the hero layout to the `post`/`post--compact` patterns used for stream items.

### Description
- Update CSS in `assets/css/style.css` to change `.hero__card` layout to a single-column grid, reduce `gap`, and set `align-items: start` for consistent sizing with stream cards.
- Move the portada badge from an absolutely positioned element to flow layout by making `.hero__card .badge` `position: static` and `align-self: flex-start`.
- Change the hero markup in `index.html` and the `HERO_TEMPLATE` in `scripts/build_posts.py` to reuse `post post--compact`, `post__thumb`, and `post__body` classes so the portada is rendered the same as stream items.

### Testing
- Launched a local HTTP server on port `8000` and ran a Playwright script to capture a screenshot, which completed successfully and produced `artifacts/portada-stream-card.png` (passed).
- No unit tests were added or run for this static layout change (not applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959abc01b40832b9dc8e03b28c44708)