### PR TITLE
Move 'En portada' label above hero card

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,12 +69,12 @@
     <section class="hero">
       <div class="container hero__grid">
         <!-- portada:begin -->
+        <h3 class="section-title">En portada</h3>
         <article class="post post--compact hero__card">
           <a href="posts/pebble-round-2-volver-a-lo-esencial.html">
             <img class="post__thumb hero__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
           </a>
           <div class="post__body hero__content">
-            <div class="badge">En portada</div>
             <h2>
               <a class="post__title-link" href="posts/pebble-round-2-volver-a-lo-esencial.html">Pebble Round 2: volver a lo esencial también es avanzar</a>
             </h2>

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -184,12 +184,12 @@ STREAM_ITEM_TEMPLATE = """        <article class="post post--compact">
           </div>
         </article>"""
 
-HERO_TEMPLATE = """        <article class="post post--compact hero__card">
+HERO_TEMPLATE = """        <h3 class="section-title">En portada</h3>
+        <article class="post post--compact hero__card">
           <a href="posts/{slug}.html">
             <img class="post__thumb hero__thumb" src="{image}" alt="{alt}" />
           </a>
           <div class="post__body hero__content">
-            <div class="badge">En portada</div>
             <h2>
               <a class="post__title-link" href="posts/{slug}.html">{title}</a>
             </h2>


### PR DESCRIPTION
### Motivation
- Make the "En portada" label appear above the hero card and match the visual pattern used for the "Stream de noticias" section title.
- Avoid duplicating the label as an inline badge inside the hero card for a cleaner layout.

### Description
- Add a section title `<h3 class="section-title">En portada</h3>` before the hero card in `index.html`.
- Remove the inline badge `<div class="badge">En portada</div>` from the static `index.html` hero markup.
- Update `HERO_TEMPLATE` in `scripts/build_posts.py` to emit the `En portada` section title and omit the inline badge when rendering the portada.

### Testing
- Served the site locally with `python -m http.server` and the server started successfully.
- Ran a Playwright script to load `http://127.0.0.1:8000/index.html` and capture a screenshot to `artifacts/en-portada.png`, which completed successfully.
- Static inspection of the generated `index.html` and `scripts/build_posts.py` confirmed the template and markup changes were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ae1bdc28832bb44f822e9c7038b3)