### PR TITLE
Fix 'En portada' title alignment in hero section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -380,6 +380,10 @@ a:focus {
   align-items: stretch;
 }
 
+.hero__grid > .section-title {
+  grid-column: 1 / -1;
+}
+
 .hero__card {
   background: var(--panel);
   border: 1px solid var(--border);


### PR DESCRIPTION
### Motivation
- The "En portada" heading was appearing to the right of the featured card instead of above it in the hero section.
- The goal is to ensure the portada title spans the full hero grid so it visually sits above the featured card.
- This can be resolved with a small CSS grid adjustment without changing the HTML markup.

### Description
- Added a rule to `assets/css/style.css`: `.hero__grid > .section-title { grid-column: 1 / -1; }` to force the title to span the grid width.
- The change is purely presentational and does not modify any HTML templates or content.
- Commit message: `Fix portada title alignment`.

### Testing
- Served the site locally using `python -m http.server 8000` and captured a visual rendering with a Playwright script which completed successfully. 
- The Playwright run produced `artifacts/hero-portada.png` showing the updated layout with the title above the card. 
- No automated unit tests were added or required for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959bf17a06c832b86153ff17a6a108d)