### PR TITLE
Add stream sidebar with tags and social placeholders

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -471,6 +471,77 @@ a:focus {
   padding-bottom: 40px;
 }
 
+.stream-layout {
+  display: grid;
+  grid-template-columns: minmax(200px, 260px) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.stream-sidebar {
+  display: grid;
+  gap: 18px;
+}
+
+.stream-card {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 10px 20px rgba(31, 19, 8, 0.08);
+  display: grid;
+  gap: 10px;
+}
+
+.stream-card h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent);
+}
+
+.stream-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.stream-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stream-card__tags span {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  color: var(--accent-strong);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+}
+
+.stream-card__social {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.stream-card__social li {
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 80%, var(--accent) 20%);
+  font-weight: 600;
+  color: var(--accent-strong);
+  letter-spacing: 0.06em;
+}
+
 .post {
   border: 1px solid var(--border);
   background: var(--panel);
@@ -1122,6 +1193,14 @@ a:focus {
 }
 
 @media (max-width: 960px) {
+  .stream-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .stream-sidebar {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
   .search-layout {
     grid-template-columns: 1fr;
   }

--- a/index.html
+++ b/index.html
@@ -103,102 +103,126 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
           <a class="category-pill" href="pages/categoria-maqueta.html">#maqueta</a>
         </div>
       </div>
-      <h3 class="section-title">Stream de noticias</h3>
-      <p id="search-status" class="search-status" role="status" aria-live="polite"></p>
-      <div id="stream" class="stream">
-        <!-- posts:begin -->
-        <article class="post post--compact">
-          <a href="posts/pebble-round-2-volver-a-lo-esencial.html">
-            <img class="post__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
-          </a>
-          <div class="post__body">
-            <h4>
-              <a class="post__title-link" href="posts/pebble-round-2-volver-a-lo-esencial.html">Pebble Round 2: volver a lo esencial también es avanzar</a>
-            </h4>
-            <div class="post__meta">
-              <span>2026-01-02</span>
-              <span>Tepokato · Wearables</span>
-            </div>
-            <p>Un smartwatch que va a contracorriente.
-La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y software abierto, dejando de lado el exceso de funciones. Un recordatorio de que volver a lo esencial también puede ser innovación.</p>
-            <div class="post__tags">
-              <span>#pebble</span>
-              <span>#smartwatch</span>
-            </div>
-            <div class="post__actions">
-              <a class="button" href="posts/pebble-round-2-volver-a-lo-esencial.html">Leer artículo</a>
-            </div>
-          </div>
-        </article>
-        <article class="post post--compact">
-          <a href="posts/anxina-paso-en-2025.html">
-            <img class="post__thumb" src="assets/img/2025anxina.png" alt="Composición editorial sobre el año 2025 en tecnología y cultura" />
-          </a>
-          <div class="post__body">
-            <h4>
-              <a class="post__title-link" href="posts/anxina-paso-en-2025.html">ANXiNA paso en 2025</a>
-            </h4>
-            <div class="post__meta">
-              <span>2025-12-31</span>
-              <span>Tepokato · Tecnología</span>
-            </div>
-            <p>2025 fue un año de ruido, promesas infladas y decisiones que sí importaron. En ANXiNA repasamos los mejores teléfonos calidad-precio, las series y películas que realmente dejaron huella, y las noticias de tecnología, ciencia y videojuegos que marcaron a Latinoamérica.</p>
-            <div class="post__tags">
+      <div class="stream-layout">
+        <aside class="stream-sidebar">
+          <div class="stream-card">
+            <h4>Tags del día</h4>
+            <p>Explora los temas más activos en el stream.</p>
+            <div class="stream-card__tags">
               <span>#tecnologia</span>
-              <span>#entretenimiento</span>
-            </div>
-            <div class="post__actions">
-              <a class="button" href="posts/anxina-paso-en-2025.html">Leer artículo</a>
-            </div>
-          </div>
-        </article>
-        <article class="post post--compact">
-          <a href="posts/menos-ram-mas-discurso.html">
-            <img class="post__thumb" src="assets/img/ram-ia.png" alt="Ilustración de módulos de RAM junto a un chip con temática de inteligencia artificial" />
-          </a>
-          <div class="post__body">
-            <h4>
-              <a class="post__title-link" href="posts/menos-ram-mas-discurso.html">La redefinición de lo “suficiente”</a>
-            </h4>
-            <div class="post__meta">
-              <span>2025-12-29</span>
-              <span>Tepokato · IA</span>
-            </div>
-            <p>Menos RAM para ti. Más memoria para la IA.</p>
-            <div class="post__tags">
               <span>#ia</span>
-            </div>
-            <div class="post__actions">
-              <a class="button" href="posts/menos-ram-mas-discurso.html">Leer artículo</a>
-            </div>
-          </div>
-        </article>
-        <article class="post post--compact">
-          <a href="posts/placeholder-post-8.html">
-            <img class="post__thumb" src="assets/img/placeholder-8.jpg" alt="Imagen de relleno para el post 8" />
-          </a>
-          <div class="post__body">
-            <h4>
-              <a class="post__title-link" href="posts/placeholder-post-8.html">Placeholder Post 8</a>
-            </h4>
-            <div class="post__meta">
-              <span>2025-01-08</span>
-              <span>Equipo ANXiNA · Diseño</span>
-            </div>
-            <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
-            <div class="post__tags">
-              <span>#placeholder</span>
+              <span>#entretenimiento</span>
+              <span>#wearables</span>
               <span>#maqueta</span>
             </div>
-            <div class="post__actions">
-              <a class="button" href="posts/placeholder-post-8.html">Leer artículo</a>
-            </div>
           </div>
-        </article>
-        <article class="post post--compact">
-          <a href="posts/placeholder-post-7.html">
-            <img class="post__thumb" src="assets/img/placeholder-7.jpg" alt="Imagen de relleno para el post 7" />
-          </a>
+          <div class="stream-card">
+            <h4>Redes sociales</h4>
+            <p>Placeholder para sumarnos a más canales.</p>
+            <ul class="stream-card__social" aria-label="Redes sociales">
+              <li>YouTube</li>
+              <li>LinkedIn</li>
+              <li>Bluesky</li>
+            </ul>
+          </div>
+        </aside>
+        <div class="stream-main">
+          <h3 class="section-title">Stream de noticias</h3>
+          <p id="search-status" class="search-status" role="status" aria-live="polite"></p>
+          <div id="stream" class="stream">
+            <!-- posts:begin -->
+            <article class="post post--compact">
+              <a href="posts/pebble-round-2-volver-a-lo-esencial.html">
+                <img class="post__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
+              </a>
+              <div class="post__body">
+                <h4>
+                  <a class="post__title-link" href="posts/pebble-round-2-volver-a-lo-esencial.html">Pebble Round 2: volver a lo esencial también es avanzar</a>
+                </h4>
+                <div class="post__meta">
+                  <span>2026-01-02</span>
+                  <span>Tepokato · Wearables</span>
+                </div>
+                <p>Un smartwatch que va a contracorriente.
+La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y software abierto, dejando de lado el exceso de funciones. Un recordatorio de que volver a lo esencial también puede ser innovación.</p>
+                <div class="post__tags">
+                  <span>#pebble</span>
+                  <span>#smartwatch</span>
+                </div>
+                <div class="post__actions">
+                  <a class="button" href="posts/pebble-round-2-volver-a-lo-esencial.html">Leer artículo</a>
+                </div>
+              </div>
+            </article>
+            <article class="post post--compact">
+              <a href="posts/anxina-paso-en-2025.html">
+                <img class="post__thumb" src="assets/img/2025anxina.png" alt="Composición editorial sobre el año 2025 en tecnología y cultura" />
+              </a>
+              <div class="post__body">
+                <h4>
+                  <a class="post__title-link" href="posts/anxina-paso-en-2025.html">ANXiNA paso en 2025</a>
+                </h4>
+                <div class="post__meta">
+                  <span>2025-12-31</span>
+                  <span>Tepokato · Tecnología</span>
+                </div>
+                <p>2025 fue un año de ruido, promesas infladas y decisiones que sí importaron. En ANXiNA repasamos los mejores teléfonos calidad-precio, las series y películas que realmente dejaron huella, y las noticias de tecnología, ciencia y videojuegos que marcaron a Latinoamérica.</p>
+                <div class="post__tags">
+                  <span>#tecnologia</span>
+                  <span>#entretenimiento</span>
+                </div>
+                <div class="post__actions">
+                  <a class="button" href="posts/anxina-paso-en-2025.html">Leer artículo</a>
+                </div>
+              </div>
+            </article>
+            <article class="post post--compact">
+              <a href="posts/menos-ram-mas-discurso.html">
+                <img class="post__thumb" src="assets/img/ram-ia.png" alt="Ilustración de módulos de RAM junto a un chip con temática de inteligencia artificial" />
+              </a>
+              <div class="post__body">
+                <h4>
+                  <a class="post__title-link" href="posts/menos-ram-mas-discurso.html">La redefinición de lo “suficiente”</a>
+                </h4>
+                <div class="post__meta">
+                  <span>2025-12-29</span>
+                  <span>Tepokato · IA</span>
+                </div>
+                <p>Menos RAM para ti. Más memoria para la IA.</p>
+                <div class="post__tags">
+                  <span>#ia</span>
+                </div>
+                <div class="post__actions">
+                  <a class="button" href="posts/menos-ram-mas-discurso.html">Leer artículo</a>
+                </div>
+              </div>
+            </article>
+            <article class="post post--compact">
+              <a href="posts/placeholder-post-8.html">
+                <img class="post__thumb" src="assets/img/placeholder-8.jpg" alt="Imagen de relleno para el post 8" />
+              </a>
+              <div class="post__body">
+                <h4>
+                  <a class="post__title-link" href="posts/placeholder-post-8.html">Placeholder Post 8</a>
+                </h4>
+                <div class="post__meta">
+                  <span>2025-01-08</span>
+                  <span>Equipo ANXiNA · Diseño</span>
+                </div>
+                <p>Artículo de relleno para pruebas de layout y componentes visuales.</p>
+                <div class="post__tags">
+                  <span>#placeholder</span>
+                  <span>#maqueta</span>
+                </div>
+                <div class="post__actions">
+                  <a class="button" href="posts/placeholder-post-8.html">Leer artículo</a>
+                </div>
+              </div>
+            </article>
+            <article class="post post--compact">
+              <a href="posts/placeholder-post-7.html">
+                <img class="post__thumb" src="assets/img/placeholder-7.jpg" alt="Imagen de relleno para el post 7" />
+              </a>
           <div class="post__body">
             <h4>
               <a class="post__title-link" href="posts/placeholder-post-7.html">Placeholder Post 7</a>
@@ -351,6 +375,8 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
         </article>
         <!-- posts:end -->
       </div>
+    </div>
+  </div>
     </section>
   </main>
 


### PR DESCRIPTION
### Motivation
- Add a narrow column to the left of the news stream to surface tags and social links as lightweight navigation and promotional UI.  
- Keep the new UI consistent with the existing panel/card aesthetic used site-wide.  
- Provide placeholders for social channels (YouTube, LinkedIn, Bluesky) so the layout is ready for integration.  
- Ensure the stream remains usable on smaller screens by stacking the sidebar responsively.

### Description
- Wrap the existing stream in a new grid layout by adding `div.stream-layout` with an `aside.stream-sidebar` and `div.stream-main` in `index.html`.  
- Add two sidebar cards in `index.html`: a `Tags del día` card with several tag pills and a `Redes sociales` card with placeholders for `YouTube`, `LinkedIn`, and `Bluesky`.  
- Add CSS in `assets/css/style.css` for `.stream-layout`, `.stream-sidebar`, `.stream-card`, `.stream-card__tags` and `.stream-card__social` to match site panels and to style tag pills and social items.  
- Make the layout responsive by changing the sidebar to stack under `@media (max-width: 960px)` so the stream stacks to a single column on small viewports.

### Testing
- Started a local dev server with `python -m http.server 8000` and the server launched successfully.  
- Ran an automated Playwright script to load `index.html` and capture a screenshot, producing `artifacts/stream-sidebar.png` successfully.  
- No unit or integration tests were added or run for these static UI changes.  
- Files modified: `index.html` and `assets/css/style.css` (changes committed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c03fe7b0832b988a64dfc76d90be)