### PR TITLE
Move categories card into sidebar and rename tags header

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,21 +92,21 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
     </section>
 
     <section id="secciones" class="container">
-      <div class="categories">
-        <h3 class="section-title">Categorías</h3>
-        <p class="categories__intro">Explora las etiquetas destacadas en el stream y salta directo a cada tema.</p>
-        <div class="categories__list" aria-label="Categorías principales">
-          <a class="category-pill" href="pages/categoria-tecnologia.html">#tecnologia</a>
-          <a class="category-pill" href="pages/categoria-entretenimiento.html">#entretenimiento</a>
-          <a class="category-pill" href="pages/categoria-ia.html">#ia</a>
-          <a class="category-pill" href="pages/categoria-placeholder.html">#placeholder</a>
-          <a class="category-pill" href="pages/categoria-maqueta.html">#maqueta</a>
-        </div>
-      </div>
       <div class="stream-layout">
         <aside class="stream-sidebar">
           <div class="stream-card">
-            <h4>Tags del día</h4>
+            <h4>Categorías</h4>
+            <p>Explora las etiquetas destacadas en el stream y salta directo a cada tema.</p>
+            <div class="categories__list" aria-label="Categorías principales">
+              <a class="category-pill" href="pages/categoria-tecnologia.html">#tecnologia</a>
+              <a class="category-pill" href="pages/categoria-entretenimiento.html">#entretenimiento</a>
+              <a class="category-pill" href="pages/categoria-ia.html">#ia</a>
+              <a class="category-pill" href="pages/categoria-placeholder.html">#placeholder</a>
+              <a class="category-pill" href="pages/categoria-maqueta.html">#maqueta</a>
+            </div>
+          </div>
+          <div class="stream-card">
+            <h4>Etiquetas</h4>
             <p>Explora los temas más activos en el stream.</p>
             <div class="stream-card__tags">
               <span>#tecnologia</span>


### PR DESCRIPTION
### Motivation
- Surface the site categories in the side column so users can access sections from the sidebar.
- Clarify naming by replacing the English-like "Tags del día" heading with the Spanish `"Etiquetas"` label.
- Keep the main stream area focused while providing quick navigation to category pages in the sidebar.

### Description
- Moved the top-level `Categorías` block into the `.stream-sidebar` and added it as a `stream-card` in `index.html`.
- Renamed the sidebar heading from `Tags del día` to `Etiquetas` and preserved the original tag list under the new heading.
- Added the `Categorías` card markup including a short intro and the list of category pills linking to `pages/categoria-*.html`.
- Only `index.html` was modified.

### Testing
- Launched a local server with `python -m http.server` and rendered `index.html` via Playwright to validate layout.
- Captured a full-page screenshot at `artifacts/side-column-categorias.png`, confirming the sidebar displays the new `Categorías` card and `Etiquetas` heading.
- No unit or integration test suite was run for this static content change.
- Commit recorded the single-file update to `index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c994b9ec832b894a52f6fd12d167)