### PR TITLE
Enhance portada hero layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -376,7 +376,7 @@ a:focus {
 .hero__grid {
   display: grid;
   gap: 24px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(12, minmax(0, 1fr));
   align-items: stretch;
 }
 
@@ -396,6 +396,14 @@ a:focus {
   position: relative;
   box-shadow: 0 6px 16px rgba(31, 19, 8, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__card--feature {
+  grid-column: 1 / -1;
+  padding: 28px;
+  gap: 28px;
+  align-items: stretch;
+  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
 }
 
 .hero__card:hover,
@@ -418,6 +426,12 @@ a:focus {
   aspect-ratio: 16 / 9;
 }
 
+.hero__card--feature .hero__thumb {
+  aspect-ratio: auto;
+  height: 100%;
+  min-height: 280px;
+}
+
 .hero__content {
   display: grid;
   gap: 12px;
@@ -425,6 +439,8 @@ a:focus {
 
 .hero__card h2 {
   margin-top: 0;
+  font-size: clamp(1.6rem, 1.2vw + 1.4rem, 2.4rem);
+  line-height: 1.2;
 }
 
 .badge {
@@ -1212,6 +1228,10 @@ a:focus {
   .result-card {
     grid-template-columns: 1fr;
   }
+
+  .hero__grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {
@@ -1328,6 +1348,11 @@ a:focus {
     padding: 16px;
     grid-template-columns: 1fr;
     justify-items: start;
+  }
+
+  .hero__card--feature {
+    padding: 18px;
+    gap: 20px;
   }
 
   .hero__card .badge {

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
       <div class="container hero__grid">
         <!-- portada:begin -->
         <h3 class="section-title">En portada</h3>
-        <article class="post post--compact hero__card">
+        <article class="post post--compact hero__card hero__card--feature">
           <a href="posts/pebble-round-2-volver-a-lo-esencial.html">
             <img class="post__thumb hero__thumb" src="assets/img/pebe1.png" alt="pebe2.png" />
           </a>

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -185,7 +185,7 @@ STREAM_ITEM_TEMPLATE = """        <article class="post post--compact">
         </article>"""
 
 HERO_TEMPLATE = """        <h3 class="section-title">En portada</h3>
-        <article class="post post--compact hero__card">
+        <article class="post post--compact hero__card hero__card--feature">
           <a href="posts/{slug}.html">
             <img class="post__thumb hero__thumb" src="{image}" alt="{alt}" />
           </a>


### PR DESCRIPTION
### Motivation
- Make the "En portada" (portada) card visually dominant so it takes up most of the top hero area and reads larger than other cards.
- Provide a unique, two-column arrangement for the featured card on wide viewports while preserving a single-column mobile layout.
- Improve image sizing and headline typography to emphasize the portada feature.

### Description
- Change grid on the hero area by updating `assets/css/style.css` to `grid-template-columns: repeat(12, minmax(0, 1fr))` and add a new `.hero__card--feature` rule to span the full grid and use a two-column layout.
- Add featured-specific image and typographic rules in `assets/css/style.css`, including `.hero__card--feature .hero__thumb` and a responsive `h2` size via `clamp()`.
- Mark the portada template as featured by adding the `hero__card--feature` class in `scripts/build_posts.py` (`HERO_TEMPLATE`) and synchronize the static sample in `index.html`.
- Preserve responsive behavior by collapsing the hero grid to a single column under `@media (max-width: 960px)` and adjust featured padding for small screens.

### Testing
- Launched a local static server with `python -m http.server` and captured a visual snapshot via Playwright, which completed successfully and saved `artifacts/portada-hero.png`.
- Verified that `index.html` and the generated `HERO_TEMPLATE` include the `hero__card--feature` class without template errors.
- No unit tests were added or run since changes are CSS/template-only and validated via the visual snapshot.
- Commit and local verification steps completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959d5a7813c832ba2ec4a4e7073139f)