### PR TITLE
Do not repeat the "En portada" post in the index stream

### DIFF
--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -576,8 +576,10 @@ def main() -> None:
         if post.status.lower() == "published" and post.source_path.exists():
             post.source_path.unlink()
 
-    stream_html = render_stream(published)
-    portada_html = render_portada(published[0]) if published else None
+    portada_post = published[0] if published else None
+    stream_posts = published[1:] if portada_post else published
+    stream_html = render_stream(stream_posts)
+    portada_html = render_portada(portada_post) if portada_post else None
     update_index(stream_html, portada_html)
 
 


### PR DESCRIPTION
### Motivation
- Prevent the featured "En portada" (hero) post from appearing twice on the homepage by removing it from the regular posts stream.
- Keep the existing portada rendering and index markers intact so the hero section is still populated independently.

### Description
- Updated `scripts/build_posts.py` to select the first published post as `portada_post` and exclude it from the stream by building `stream_posts` from `published[1:]`.
- Changed the call to `render_stream` to use `stream_posts` and `render_portada` to use `portada_post` while preserving behavior when there are no published posts.
- No other template or marker handling was modified; `update_index` and portada markers remain unchanged.

### Testing
- No automated tests were run after this change.
- Static checks and runtime execution were not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959db80baf4832b8b587248470efbd1)