### PR TITLE
Move theme toggle to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,10 +57,6 @@
             <a href="pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -387,6 +383,10 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
         <a href="pages/politica_de_privacidad.html">política de privacidad</a> y los
         <a href="pages/terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="assets/js/theme-toggle.js"></script>

--- a/pages/404.html
+++ b/pages/404.html
@@ -41,10 +41,6 @@
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -87,6 +83,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -94,6 +90,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -72,6 +68,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -72,6 +68,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -73,6 +69,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -72,6 +68,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -72,6 +68,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -37,10 +37,6 @@
             <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -103,6 +99,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -102,6 +98,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/search.html
+++ b/pages/search.html
@@ -48,10 +48,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -230,6 +226,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -37,10 +37,6 @@
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </header>
@@ -102,6 +98,10 @@
         <a href="politica_de_privacidad.html">política de privacidad</a> y los
         <a href="terminos_de_servicio.html">términos</a>.
       </p>
+      <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+        <span class="theme-toggle__switch" aria-hidden="true"></span>
+      </button>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>


### PR DESCRIPTION
### Motivation
- Move the theme switch control from the header to the footer to change its visual placement across the site.
- Keep the existing toggle markup and behavior intact while changing where it appears in the layout.
- Apply the change consistently across top-level pages and category/static pages.

### Description
- Removed the `button.theme-toggle` from the header and added the same `button.theme-toggle` markup inside each page's footer.
- Updated `index.html` and multiple files under `pages/` (category pages, `contactanos.html`, `search.html`, `404.html`, etc.) to reflect the relocation.
- Left `assets/js/theme-toggle.js` and script includes unchanged so the toggle behavior is preserved.
- Changes are purely static HTML updates; markup is unchanged except for its placement.

### Testing
- Started a local server with `python -m http.server` to serve the updated pages (server started successfully).
- Attempted to capture a screenshot with Playwright/headless Chromium to visually verify placement, but Playwright crashed during Chromium launch and the screenshot run failed.
- No automated unit or integration test suite was executed for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959e4132500832bae28fb95d1b6e531)