### PR TITLE
Highlight active Search navigation link

### DIFF
--- a/pages/search.html
+++ b/pages/search.html
@@ -34,7 +34,7 @@
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
-          <a href="search.html">Buscar</a>
+          <a class="active" href="search.html" aria-current="page">Buscar</a>
           <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
@@ -44,7 +44,7 @@
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
-            <a href="search.html">Buscar</a>
+            <a class="active" href="search.html" aria-current="page">Buscar</a>
             <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>


### PR DESCRIPTION
### Motivation
- The search page header did not show the leading `./` prefix or accent color for the "Buscar" link in the top bar.  
- The active state needed to be consistent between the desktop `.nav-inline` and the mobile `nav-menu__panel`.  
- Adding an explicit page indicator improves visual feedback and accessibility.  

### Description
- Added `class="active"` and `aria-current="page"` to the "Buscar" links in `pages/search.html` for both the inline and menu panels.  
- This change leverages the existing CSS selector `a.active::before` to display the `./` prefix and accent color without modifying styles.  
- The update is limited to static HTML and does not alter any JS or server code.  

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script to capture a visual screenshot of the header, which completed successfully.  
- A screenshot artifact was produced at `artifacts/search-nav.png` for visual verification.  
- No automated unit tests were required for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959ea4c4610832bb6e5e22a51e3a9eb)