### PR TITLE
Show date, author and tags on 'En portada' hero card

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,10 +74,18 @@
             <h2>
               <a class="post__title-link" href="posts/pebble-round-2-volver-a-lo-esencial.html">Pebble Round 2: volver a lo esencial también es avanzar</a>
             </h2>
+            <div class="post__meta">
+              <span>2026-01-02</span>
+              <span>Tepokato · Wearables</span>
+            </div>
             <p>
               Un smartwatch que va a contracorriente.
 La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y software abierto, dejando de lado el exceso de funciones. Un recordatorio de que volver a lo esencial también puede ser innovación.
             </p>
+            <div class="post__tags">
+              <span>#pebble</span>
+              <span>#smartwatch</span>
+            </div>
             <div class="post__actions">
               <a class="button" href="posts/pebble-round-2-volver-a-lo-esencial.html">Leer artículo</a>
             </div>

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -193,7 +193,14 @@ HERO_TEMPLATE = """        <h3 class="section-title">En portada</h3>
             <h2>
               <a class="post__title-link" href="posts/{slug}.html">{title}</a>
             </h2>
+            <div class="post__meta">
+              <span>{date}</span>
+              <span>{author} · {category}</span>
+            </div>
             <p>{summary}</p>
+            <div class="post__tags">
+{tags}
+            </div>
             <div class="post__actions">
               <a class="button" href="posts/{slug}.html">Leer artículo</a>
             </div>
@@ -509,6 +516,10 @@ def render_portada(post: Post) -> str:
         alt=html.escape(post.featured_image_alt),
         title=html.escape(post.title),
         summary=html.escape(post.summary),
+        date=html.escape(post.date),
+        author=html.escape(post.author),
+        category=html.escape(post.category),
+        tags=format_tags(post.tags, limit=3, indent="              "),
         slug=html.escape(post.slug),
     )
 


### PR DESCRIPTION
### Motivation
- The featured post card in the "En portada" section lacked metadata (date/author/tags) that other stream items render.  
- Make the portada hero consistent with the stream item layout so readers can see key info at a glance.  

### Description
- Extended the `HERO_TEMPLATE` to include a `post__meta` block and a `post__tags` block for metadata and tags.  
- Updated `render_portada` to pass `date`, `author`, `category`, and formatted `tags` (`limit=3`, `indent="              "`).  
- Updated `index.html` markup for the current featured post so the homepage shows the new metadata and tags.  

### Testing
- Ran `python3 scripts/build_posts.py` which completed without errors and produced updated output.  
- Started a local server with `python3 -m http.server 8000` and rendered the homepage with a Playwright script to verify the hero card layout.  
- The Playwright run produced a screenshot artifact (`artifacts/portada.png`) confirming the metadata and tags are visible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f8944c5c832bafcf016ccc0036d2)