### PR TITLE
Add minimal SEO/Open Graph metadata to category, search and 404 pages

### DIFF
--- a/pages/404.html
+++ b/pages/404.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · 404</title>
+  <meta name="description" content="Página no encontrada en ANXiNA. Regresa al inicio o explora las categorías destacadas para retomar la transmisión." />
+  <link rel="canonical" href="404.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA · 404" />
+  <meta property="og:description" content="Página no encontrada en ANXiNA. Regresa al inicio o explora las categorías destacadas para retomar la transmisión." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="404.html" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Entretenimiento</title>
+  <meta name="description" content="Series, videojuegos y cultura pop con enfoque crítico. Aquí se agrupan las notas marcadas con #entretenimiento." />
+  <link rel="canonical" href="categoria-entretenimiento.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA · Categoría Entretenimiento" />
+  <meta property="og:description" content="Series, videojuegos y cultura pop con enfoque crítico. Aquí se agrupan las notas marcadas con #entretenimiento." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="categoria-entretenimiento.html" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría IA</title>
+  <meta name="description" content="Lo último en inteligencia artificial, modelos, debates éticos y usos creativos. En esta página reunimos el contenido con la etiqueta #ia." />
+  <link rel="canonical" href="categoria-ia.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA · Categoría IA" />
+  <meta property="og:description" content="Lo último en inteligencia artificial, modelos, debates éticos y usos creativos. En esta página reunimos el contenido con la etiqueta #ia." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="categoria-ia.html" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Maqueta</title>
+  <meta name="description" content="Espacio dedicado a bocetos, exploraciones visuales y pruebas editoriales. Aquí están las notas etiquetadas con #maqueta." />
+  <link rel="canonical" href="categoria-maqueta.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA · Categoría Maqueta" />
+  <meta property="og:description" content="Espacio dedicado a bocetos, exploraciones visuales y pruebas editoriales. Aquí están las notas etiquetadas con #maqueta." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="categoria-maqueta.html" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Placeholder</title>
+  <meta name="description" content="Contenido de prueba para validar layouts y componentes. Aquí quedan agrupadas las entradas etiquetadas como #placeholder." />
+  <link rel="canonical" href="categoria-placeholder.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA · Categoría Placeholder" />
+  <meta property="og:description" content="Contenido de prueba para validar layouts y componentes. Aquí quedan agrupadas las entradas etiquetadas como #placeholder." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="categoria-placeholder.html" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Categoría Tecnología</title>
+  <meta name="description" content="Noticias, análisis y actualizaciones clave de hardware, software y cultura digital. Aquí reunimos las piezas etiquetadas con #tecnologia." />
+  <link rel="canonical" href="categoria-tecnologia.html" />
+  <meta property="og:site_name" content="ANXiNA" />
+  <meta property="og:title" content="ANXiNA · Categoría Tecnología" />
+  <meta property="og:description" content="Noticias, análisis y actualizaciones clave de hardware, software y cultura digital. Aquí reunimos las piezas etiquetadas con #tecnologia." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="categoria-tecnologia.html" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />

--- a/pages/search.html
+++ b/pages/search.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ANXiNA · Resultados de búsqueda</title>
-  <meta name="description" content="Resultados de búsqueda en ANXiNA." />
+  <meta name="description" content="Encuentra noticias, reseñas y reportajes en ANXiNA." />
   <link rel="canonical" href="search.html" />
   <meta property="og:site_name" content="ANXiNA" />
   <meta property="og:title" content="ANXiNA · Resultados de búsqueda" />


### PR DESCRIPTION
### Motivation
- Provide a minimal metadata template (title, description, canonical, OG title/description/url/type) for non-article pages to improve sharing and SEO.
- Apply consistent metadata across category pages so each category uses its page title and URL for metadata.
- Ensure utility pages (`search` and `404`) have appropriate descriptions and `og:type` values (website) matching the site style.
- Keep URLs relative and metadata style consistent with existing `index.html` and post pages.

### Description
- Added `meta name="description"`, `link rel="canonical"` and OG tags (`og:site_name`, `og:title`, `og:description`, `og:type`, `og:url`) to `pages/categoria-*.html` files using each page's title and relative URL.
- Added the same minimal metadata to `pages/404.html` with a suitable description and `og:type` set to `website`.
- Updated `pages/search.html` description to a clearer site-wide phrasing and kept its canonical/OG URL relative (`search.html`).
- All changes are static HTML edits and preserve the existing relative link structure used in `index.html` and `posts` pages.

### Testing
- No automated tests were run because these are static HTML metadata changes only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a8b0ef4b0832b8ec4aa5a1be878dd)