### PR TITLE
Add back-to-top button across site

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -943,6 +943,44 @@ a:focus {
   border-bottom: none;
 }
 
+.back-to-top {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--button-bg);
+  color: var(--button-text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 24px var(--shadow);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+  z-index: 20;
+}
+
+.back-to-top.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.back-to-top:hover {
+  background: var(--accent);
+  color: var(--panel);
+}
+
+.back-to-top:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .footer {
   border-top: 1px solid var(--border);
   padding: 24px 0 40px;

--- a/assets/js/back-to-top.js
+++ b/assets/js/back-to-top.js
@@ -1,0 +1,18 @@
+const backToTop = document.querySelector('.back-to-top');
+
+if (backToTop) {
+  const toggleVisibility = () => {
+    if (window.scrollY > 300) {
+      backToTop.classList.add('is-visible');
+    } else {
+      backToTop.classList.remove('is-visible');
+    }
+  };
+
+  backToTop.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+
+  window.addEventListener('scroll', toggleVisibility, { passive: true });
+  toggleVisibility();
+}

--- a/index.html
+++ b/index.html
@@ -252,6 +252,11 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
     </section>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -268,5 +273,6 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
   <script src="assets/js/theme-toggle.js"></script>
   <script src="assets/js/nav-menu.js"></script>
   <script src="assets/js/search-filter.js"></script>
+  <script src="assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/404.html
+++ b/pages/404.html
@@ -79,6 +79,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -94,5 +99,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -83,6 +83,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -98,5 +103,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -68,6 +68,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -83,5 +88,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -68,6 +68,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -83,5 +88,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -69,6 +69,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -84,5 +89,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -68,6 +68,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -83,5 +88,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -68,6 +68,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -83,5 +88,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -92,6 +92,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -107,5 +112,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -91,6 +91,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -106,5 +111,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/search.html
+++ b/pages/search.html
@@ -219,6 +219,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -235,5 +240,6 @@
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
   <script src="../assets/js/search-page.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -91,6 +91,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -106,5 +111,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -171,6 +171,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -181,5 +186,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -146,6 +146,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -156,5 +161,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -134,6 +134,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -144,5 +149,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -179,6 +179,11 @@
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container">
       <p>
@@ -189,5 +194,6 @@
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a compact, accessible way for users to quickly return to the top of long pages using a familiar Bootstrap arrow icon.
- Keep the UI minimal (icon-only) and consistent with existing site styles and iconography.

### Description
- Inserted a `.back-to-top` button (markup uses the `bi bi-arrow-up` Bootstrap Icon) into main templates and pages so it appears across the site.
- Added `assets/js/back-to-top.js` which toggles `is-visible` based on scroll position and performs a smooth `window.scrollTo` on click.
- Added styling for `.back-to-top`, `.back-to-top.is-visible`, hover and focus states in `assets/css/style.css` including sizing, placement and transitions.
- Appended the `back-to-top` script tag to pages so the behavior is loaded site-wide.

### Testing
- Launched a local dev server with `python -m http.server` which started successfully for browser verification.
- Ran a Playwright script that opened `http://127.0.0.1:8000/index.html`, scrolled the page and captured a screenshot (`artifacts/back-to-top.png`), and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a8e9c9c3c832b94f2e9610f82cbec)