### PR TITLE
Fix hero side-panel grid spans

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -926,6 +926,14 @@ a:focus {
   padding: 18px;
 }
 
+.hero__grid > .side-panel {
+  grid-column: span 6;
+}
+
+.hero__grid > .side-panel:only-child {
+  grid-column: 1 / -1;
+}
+
 .side-panel ul {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
### Motivation
- Contact, privacy, and terms pages showed a narrow card layout for side panels inside hero grids.
- Side panels should occupy half the hero grid by default and span full width when lone.
- Make layout consistent across hero sections.

### Description
- Added CSS rules in `assets/css/style.css` targeting `.hero__grid > .side-panel` to `grid-column: span 6`.
- Added a rule for `.hero__grid > .side-panel:only-child` to `grid-column: 1 / -1` so a single panel spans full width.
- Only `assets/css/style.css` was modified.

### Testing
- Started a local server with `python -m http.server` and it served the site successfully.
- Rendered `pages/contactanos.html` with Playwright and captured `artifacts/contactanos.png` to visually verify the layout, which completed successfully.
- No unit or integration test suite was executed for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9144682c832b8876e63e8fc66f51)