### PR TITLE
Move theme toggle to header and remove header “Contáctanos” links

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
           <a class="active" href="index.html" aria-current="page">Inicio</a>
           <a href="#secciones">Secciones/Categorías</a>
           <a href="pages/search.html">Buscar</a>
-          <a href="pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -54,9 +53,12 @@
             <a class="active" href="index.html" aria-current="page">Inicio</a>
             <a href="#secciones">Secciones/Categorías</a>
             <a href="pages/search.html">Buscar</a>
-            <a href="pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -278,10 +280,6 @@ La Pebble Round 2 apuesta por diseño delgado, batería de hasta 14 días y soft
           <li><a href="pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/404.html
+++ b/pages/404.html
@@ -31,7 +31,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -41,9 +40,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -105,10 +107,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -24,7 +24,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -34,9 +33,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -109,10 +111,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -31,7 +31,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -41,9 +40,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -94,10 +96,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -31,7 +31,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -41,9 +40,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -94,10 +96,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -31,7 +31,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -41,9 +40,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -95,10 +97,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -31,7 +31,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -41,9 +40,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -94,10 +96,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -31,7 +31,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -41,9 +40,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -94,10 +96,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -24,7 +24,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -34,9 +33,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a class="active" href="contactanos.html" aria-current="page">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -118,10 +120,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -24,7 +24,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -34,9 +33,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -117,10 +119,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/search.html
+++ b/pages/search.html
@@ -35,7 +35,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a class="active" href="search.html" aria-current="page">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -45,9 +44,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a class="active" href="search.html" aria-current="page">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -245,10 +247,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -24,7 +24,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
-          <a href="contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -34,9 +33,12 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
-            <a href="contactanos.html">Contáctanos</a>
           </nav>
         </details>
+        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
+          <span class="theme-toggle__switch" aria-hidden="true"></span>
+        </button>
       </div>
     </div>
   </header>
@@ -117,10 +119,6 @@
           <li><a href="terminos_de_servicio.html">Términos</a></li>
           <li><a href="contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -197,10 +195,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -172,10 +170,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -160,10 +158,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -67,7 +67,6 @@
           <a href="../index.html">Inicio</a>
           <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
         </nav>
       </div>
       <div class="header-meta">
@@ -77,7 +76,6 @@
             <a href="../index.html">Inicio</a>
             <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
-            <a href="../pages/contactanos.html">Contáctanos</a>
           </nav>
         </details>
         <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
@@ -205,10 +203,6 @@
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
### Motivation
- Restore the theme switch to the header so it is consistently available in the primary UI area.  
- Remove duplicate "Contáctanos" links from header navs since the contact page is already available in the footer.  
- Keep footer legal links intact and maintain a single place for site-level contact access.  
- Clean up some compacted HTML closing tags that made the markup harder to read and maintain.

### Description
- Removed the `Contáctanos` anchor from the top `nav.nav-inline` and the mobile `nav-menu__panel` across `index.html`, `pages/*.html` and `posts/*.html`.  
- Inserted the theme toggle button markup (`<button class="theme-toggle">…</button>`) inside each page's `div.header-meta` so the control appears in the header.  
- Removed the footer theme toggle buttons so only the header contains the theme control while keeping the footer `Contáctanos` link.  
- Fixed compacted `</ul></div>` instances by expanding them to `</ul>\n      </div>` to improve HTML formatting across multiple files.

### Testing
- Ran a repository-wide search to confirm header `Contáctanos` links were removed and the `theme-toggle` button moved to headers, which matched the intended changes.  
- Launched a local static server with `python -m http.server` and captured a screenshot using Playwright to visually verify the header contains the theme toggle, which succeeded.  
- Executed the automated Python scripts used for the markup edits to apply replacements across the site without errors.  
- No unit tests apply for this static site change; the manual/automated checks above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a97f77bd8832b9fe37f0efc18d5d9)