### PR TITLE
Remove Secciones/Categorías navigation link site-wide

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a class="active" href="index.html" aria-current="page">Inicio</a>
-          <a href="#secciones">Secciones/Categorías</a>
           <a href="pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -51,7 +50,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a class="active" href="index.html" aria-current="page">Inicio</a>
-            <a href="#secciones">Secciones/Categorías</a>
             <a href="pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/404.html
+++ b/pages/404.html
@@ -29,7 +29,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -38,7 +37,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -22,7 +22,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -31,7 +30,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -29,7 +29,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -38,7 +37,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -29,7 +29,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -38,7 +37,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -29,7 +29,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -38,7 +37,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -29,7 +29,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -38,7 +37,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -29,7 +29,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -38,7 +37,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -22,7 +22,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -31,7 +30,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -22,7 +22,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -31,7 +30,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/search.html
+++ b/pages/search.html
@@ -33,7 +33,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a class="active" href="search.html" aria-current="page">Buscar</a>
         </nav>
       </div>
@@ -42,7 +41,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a class="active" href="search.html" aria-current="page">Buscar</a>
           </nav>
         </details>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -22,7 +22,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="search.html">Buscar</a>
         </nav>
       </div>
@@ -31,7 +30,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -65,7 +65,6 @@
         </div>
         <nav class="nav-inline" aria-label="Navegación principal">
           <a href="../index.html">Inicio</a>
-          <a href="../index.html#secciones">Secciones/Categorías</a>
           <a href="../pages/search.html">Buscar</a>
         </nav>
       </div>
@@ -74,7 +73,6 @@
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-            <a href="../index.html#secciones">Secciones/Categorías</a>
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>


### PR DESCRIPTION
### Motivation
- Remove the top-level "Secciones/Categorías" navigation link from the header across the site to simplify the main navigation.
- Ensure the header remains focused on primary actions (Inicio, Buscar, menu, theme toggle) without the categories anchor.
- Apply the change consistently to all static pages and post templates so generated and hand-authored pages match.

### Description
- Deleted the `<a ...>Secciones/Categorías</a>` anchor from the header navigation in `index.html` and every file under `pages/` and `posts/` that contained it.
- Applied a repository-wide script-based cleanup to remove remaining occurrences of the link text/anchor.
- Left other header elements (search, menu/`<details>`, and theme toggle) unchanged to preserve existing UX.

### Testing
- Searched the repository with `rg` to confirm no remaining `Secciones/Categorías` matches and the search returned no hits, indicating success.
- Launched a local HTTP server (`python -m http.server`) and captured a screenshot with Playwright to visually verify the header no longer shows the link, which produced an artifact.
- No unit tests apply to this static markup-only change, so no additional automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a99c371d4832b8c6312ea30ea4eed)