### PR TITLE
Move Inicio/Buscar next to logo and fix theme toggle to top-right

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -93,8 +93,15 @@ a:focus {
 .header-top {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 28px;
+  flex-wrap: wrap;
+}
+
+.header-top__main {
+  display: flex;
+  align-items: center;
+  gap: 24px;
   flex-wrap: wrap;
 }
 
@@ -353,6 +360,13 @@ a:focus {
   color: var(--text);
   font-weight: 600;
   cursor: pointer;
+}
+
+.theme-toggle--fixed {
+  position: fixed;
+  top: 16px;
+  right: 20px;
+  z-index: 50;
 }
 
 .theme-toggle__icon {

--- a/index.html
+++ b/index.html
@@ -33,17 +33,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a class="active" href="index.html" aria-current="page">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a class="active" href="index.html" aria-current="page">Inicio</a>
           <a href="pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -53,7 +55,7 @@
             <a href="pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/404.html
+++ b/pages/404.html
@@ -20,17 +20,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -40,7 +42,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -13,17 +13,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -33,7 +35,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -20,17 +20,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -40,7 +42,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -20,17 +20,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -40,7 +42,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -20,17 +20,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -40,7 +42,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -20,17 +20,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -40,7 +42,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -20,17 +20,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -40,7 +42,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -13,17 +13,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -33,7 +35,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -13,17 +13,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -33,7 +35,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/search.html
+++ b/pages/search.html
@@ -24,17 +24,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a class="active" href="search.html" aria-current="page">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -44,7 +46,7 @@
             <a class="active" href="search.html" aria-current="page">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -13,17 +13,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -33,7 +35,7 @@
             <a href="search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/anxina-paso-en-2025.html
+++ b/posts/anxina-paso-en-2025.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/menos-ram-mas-discurso.html
+++ b/posts/menos-ram-mas-discurso.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/pebble-round-2-volver-a-lo-esencial.html
+++ b/posts/pebble-round-2-volver-a-lo-esencial.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-1.html
+++ b/posts/placeholder-post-1.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-2.html
+++ b/posts/placeholder-post-2.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-3.html
+++ b/posts/placeholder-post-3.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-4.html
+++ b/posts/placeholder-post-4.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-5.html
+++ b/posts/placeholder-post-5.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-6.html
+++ b/posts/placeholder-post-6.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-7.html
+++ b/posts/placeholder-post-7.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/posts/placeholder-post-8.html
+++ b/posts/placeholder-post-8.html
@@ -56,17 +56,19 @@
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav-inline" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav-inline" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/search.html">Buscar</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <details class="nav-menu">
@@ -76,7 +78,7 @@
             <a href="../pages/search.html">Buscar</a>
           </nav>
         </details>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>

--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -99,27 +99,29 @@ HTML_TEMPLATE = """<!DOCTYPE html>
   <header class="site-header">
     <div class="container">
       <div class="header-top">
-        <div class="brand">
-          <a class="brand__link" href="../index.html">
-            <div class="brand__badge">
-              <h1 class="brand__title">ANXiNA</h1>
-            </div>
-          </a>
-        </div>
-        <nav class="nav" aria-label="Navegación principal">
-          <a href="../index.html">Inicio</a>
+        <div class="header-top__main">
+          <div class="brand">
+            <a class="brand__link" href="../index.html">
+              <div class="brand__badge">
+                <h1 class="brand__title">ANXiNA</h1>
+              </div>
+            </a>
+          </div>
+          <nav class="nav" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
           <a href="../pages/contactanos.html">Contáctanos</a>
           <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
           <a href="../pages/benefactores.html">Benefactores</a>
           <a href="../pages/terminos_de_servicio.html">Términos</a>
-        </nav>
+          </nav>
+        </div>
       </div>
       <div class="header-meta">
         <label class="search" aria-label="Buscar en ANXiNA">
           <span class="search__prompt" aria-hidden="true">&gt;_</span>
           <input type="search" placeholder="buscar..." />
         </label>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
+        <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
         </button>


### PR DESCRIPTION
### Motivation
- Position the primary navigation links (`Inicio`, `Buscar`) immediately next to the site badge so the brand and primary actions are grouped together. 
- Keep the theme toggle accessible and visually separate by fixing it to the top-right of the viewport. 
- Ensure generated post pages created by the build script use the same header structure as the hand-edited pages. 
- Make minimal CSS/layout changes to achieve the above without altering visual styling elsewhere.

### Description
- Update header markup across `index.html`, `pages/*.html`, `posts/*.html` and `scripts/build_posts.py` to wrap the logo and inline nav in a new `header-top__main` container. 
- Add CSS changes in `assets/css/style.css` to set `.header-top` alignment to `flex-start`, introduce `.header-top__main`, and add `.theme-toggle--fixed` to fix the toggle at `top: 16px; right: 20px`. 
- Add the `theme-toggle--fixed` modifier to theme toggle buttons in all affected HTML and in the `HTML_TEMPLATE` inside `scripts/build_posts.py` so generated posts match the updated layout. 
- Apply small whitespace/indentation cleanups in multiple HTML files to keep markup consistent.

### Testing
- Served the site locally with `python -m http.server 8000` and verified the server started successfully. 
- Ran a Playwright script to capture a header screenshot (`artifacts/header-layout.png`) which completed successfully and shows the nav next to the logo with the theme toggle fixed to the top-right. 
- No unit or integration test suite was applicable for these static HTML/CSS changes. 
- All automated steps performed (server + screenshot) succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9b779f54832b87259f55ab6a281f)