### PR TITLE
Align post generator layout with index

### DIFF
--- a/scripts/build_posts.py
+++ b/scripts/build_posts.py
@@ -87,9 +87,9 @@ HTML_TEMPLATE = """<!DOCTYPE html>
   <meta name="twitter:image" content="{og_image}" />
   <meta name="twitter:image:alt" content="{og_image_alt}" />
   <meta name="theme-color" content="#f6efe6" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@latest/font/bootstrap-icons.min.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <script type="application/ld+json">
 {json_ld}
   </script>
@@ -107,20 +107,20 @@ HTML_TEMPLATE = """<!DOCTYPE html>
               </div>
             </a>
           </div>
-          <nav class="nav" aria-label="Navegación principal">
+          <nav class="nav-inline" aria-label="Navegación principal">
             <a href="../index.html">Inicio</a>
-          <a href="../pages/contactanos.html">Contáctanos</a>
-          <a href="../pages/politica_de_privacidad.html">Política de privacidad</a>
-          <a href="../pages/benefactores.html">Benefactores</a>
-          <a href="../pages/terminos_de_servicio.html">Términos</a>
+            <a href="../pages/search.html">Buscar</a>
           </nav>
         </div>
       </div>
       <div class="header-meta">
-        <label class="search" aria-label="Buscar en ANXiNA">
-          <span class="search__prompt" aria-hidden="true">&gt;_</span>
-          <input type="search" placeholder="buscar..." />
-        </label>
+        <details class="nav-menu">
+          <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
+          <nav class="nav-menu__panel" aria-label="Navegación principal">
+            <a href="../index.html">Inicio</a>
+            <a href="../pages/search.html">Buscar</a>
+          </nav>
+        </details>
         <button class="theme-toggle theme-toggle--fixed" type="button" aria-pressed="false" aria-label="Activar tema claro">
           <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
           <span class="theme-toggle__switch" aria-hidden="true"></span>
@@ -149,6 +149,11 @@ HTML_TEMPLATE = """<!DOCTYPE html>
     </div>
   </main>
 
+
+  <button class="back-to-top" type="button" aria-label="Volver al inicio">
+    <i class="bi bi-arrow-up" aria-hidden="true"></i>
+  </button>
+
   <footer class="footer">
     <div class="container footer__content">
       <div class="footer__column">
@@ -170,15 +175,12 @@ HTML_TEMPLATE = """<!DOCTYPE html>
           <li><a href="../pages/terminos_de_servicio.html">Términos</a></li>
           <li><a href="../pages/contactanos.html">Contáctanos</a></li>
         </ul>
-        <button class="theme-toggle" type="button" aria-pressed="false" aria-label="Activar tema claro">
-          <i class="theme-toggle__icon bi bi-moon-fill" aria-hidden="true"></i>
-          <span class="theme-toggle__switch" aria-hidden="true"></span>
-        </button>
       </div>
     </div>
   </footer>
   <script src="../assets/js/theme-toggle.js"></script>
   <script src="../assets/js/nav-menu.js"></script>
+  <script src="../assets/js/back-to-top.js"></script>
 </body>
 </html>
 """


### PR DESCRIPTION
### Motivation
- Ensure generated post pages follow the same header/footer and behavior as the site `index.html` for consistent navigation and UX.
- Replace generator-only header pieces with the site-wide menu structure to avoid diverging markup across pages.
- Include the same site font and back-to-top affordance used on other pages so generated posts match visual and interaction patterns.

### Description
- Update `scripts/build_posts.py` `HTML_TEMPLATE` to add the IBM Plex font link and remove the unused Material Symbols stylesheet.
- Replace the generator-specific header search and `nav` with a `nav-inline` and a `details`-based menu that links to `../pages/search.html` for parity with `index.html`.
- Insert a `back-to-top` button into the post template and add the `../assets/js/back-to-top.js` script include, and remove the duplicated footer theme-toggle control.
- All changes were made in `scripts/build_posts.py` to affect future generated post HTML files.

### Testing
- No automated tests were run for this change.
- Local repository changes were committed successfully (non-test verification only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9e7d3de8832bba1b1d312b33ed39)