### PR TITLE
Remove redundant 'Inicio' links from header navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a class="active" href="index.html" aria-current="page">Inicio</a>
-          <a href="pages/search.html">Buscar</a>
+            <a href="pages/search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -51,7 +50,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a class="active" href="index.html" aria-current="page">Inicio</a>
             <a href="pages/search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/404.html
+++ b/pages/404.html
@@ -29,8 +29,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -38,7 +37,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/benefactores.html
+++ b/pages/benefactores.html
@@ -22,8 +22,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -31,7 +30,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-entretenimiento.html
+++ b/pages/categoria-entretenimiento.html
@@ -29,8 +29,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -38,7 +37,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-ia.html
+++ b/pages/categoria-ia.html
@@ -29,8 +29,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -38,7 +37,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-maqueta.html
+++ b/pages/categoria-maqueta.html
@@ -29,8 +29,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -38,7 +37,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-placeholder.html
+++ b/pages/categoria-placeholder.html
@@ -29,8 +29,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -38,7 +37,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/categoria-tecnologia.html
+++ b/pages/categoria-tecnologia.html
@@ -29,8 +29,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -38,7 +37,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/contactanos.html
+++ b/pages/contactanos.html
@@ -22,8 +22,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -31,7 +30,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/politica_de_privacidad.html
+++ b/pages/politica_de_privacidad.html
@@ -22,8 +22,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -31,7 +30,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>

--- a/pages/search.html
+++ b/pages/search.html
@@ -33,7 +33,6 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
           <a class="active" href="search.html" aria-current="page">Buscar</a>
           </nav>
         </div>
@@ -42,7 +41,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a class="active" href="search.html" aria-current="page">Buscar</a>
           </nav>
         </details>

--- a/pages/terminos_de_servicio.html
+++ b/pages/terminos_de_servicio.html
@@ -22,8 +22,7 @@
             </a>
           </div>
           <nav class="nav-inline" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
-          <a href="search.html">Buscar</a>
+            <a href="search.html">Buscar</a>
           </nav>
         </div>
       </div>
@@ -31,7 +30,6 @@
         <details class="nav-menu">
           <summary><i class="bi bi-list" aria-hidden="true"></i><span>Menú</span></summary>
           <nav class="nav-menu__panel" aria-label="Navegación principal">
-            <a href="../index.html">Inicio</a>
             <a href="search.html">Buscar</a>
           </nav>
         </details>


### PR DESCRIPTION
### Motivation
- The brand/logo already links to the homepage, so the explicit `Inicio` links in the header were redundant.
- Simplify the top navigation to reduce visual clutter and emphasize primary actions.
- Make header markup consistent across all page templates.

### Description
- Removed the `Inicio` anchor from the inline navigation and the menu panel in `index.html` and all `pages/*.html` files.
- Preserved the brand/logo link as the home route and kept the `Buscar` link as the only visible header navigation item.
- The change updates the site header across 12 HTML files (root `index.html` plus templates under `pages/`).

### Testing
- Served the site locally with `python -m http.server 8000` and captured a visual verification screenshot using Playwright, which completed successfully.
- Performed a repository-wide search to confirm `Inicio` anchors were removed and that `Buscar` remains present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bf92cb224832b9096870ebd4b12a7)